### PR TITLE
Harden destructive CLI actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,10 +106,13 @@ pnpm build
 - `comment list` defaults to site-wide admin moderation semantics and includes replies unless `--top-level-only` is passed.
 - `comment get` uses Ghost Admin's moderation read include set, and `comment thread` mirrors the Admin moderation sidebar by combining the selected comment read with the filtered thread query.
 - `comment hide|show|delete` map to Ghost Admin comment status transitions (`hidden`, `published`, `deleted`).
+- `auth logout` requires confirmation when removing all configured sites; non-interactive use requires `--yes`.
+- `auth link` requires confirmation before replacing an existing project link; non-interactive use requires `--yes`, and relinking updates the discovered project config within the enclosing repo.
 - `post publish|schedule` supports `--newsletter`, `--email-segment`, and `--email-only`.
 - `post delete` supports either `<id>` or `--filter` (non-interactive delete requires `--yes`).
 - `post bulk` supports `--action` plus compatibility aliases `--update`/`--delete` and update fields including `--add-tag` and `--authors`.
 - `member list --status` composes with `--filter`.
+- `member export --output`, `stats ... --csv --output`, and `migrate export --output` refuse to overwrite an existing file.
 - `member update --expiry` supports complimentary tier expiry when used with `--tier`.
 - `member bulk` keeps `--action` and supports compatibility aliases `--update`, `--delete`, `--labels`, `--yes`.
 - `tier list --include` is supported.
@@ -118,6 +121,7 @@ pnpm build
 - `stats web` and `stats post ... web` use Ghost Admin stats routes where available and internal Tinybird reads for web traffic datasets Ghost does not wrap.
 - `socialweb` uses the existing staff-token Admin API flow to mint a short-lived identity JWT from `/ghost/api/admin/identities/`, then uses that bearer token against `/.ghost/activitypub/v1/*`.
 - `socialweb` requires an Owner/Admin staff token and is intentionally limited to Ghost's private social web admin surface; neither the CLI nor MCP expose public federation endpoints.
+- `socialweb delete` requires confirmation; non-interactive use requires `--yes`.
 - `stats growth` clips broader Ghost member/MRR/subscription histories client-side to the selected window when upstream endpoints cannot express the full range.
 - `stats post ... growth` clips Ghost lifetime post-growth history client-side to the selected window.
 - Ghost analytics semantics: `source` and `utm_*` filters are session-scoped, while post/member-status filters are hit-scoped.

--- a/README.md
+++ b/README.md
@@ -109,10 +109,14 @@ Site/profile management:
 ghst auth list
 ghst auth switch <site-alias>
 ghst auth link --site <site-alias>
+ghst auth link --site <site-alias> --yes
+ghst auth logout --yes
 ghst auth token
 ```
 
 `ghst auth token` prints a short-lived staff JWT. Treat the output as sensitive.
+`ghst auth logout` requires confirmation when removing all configured sites; use `--yes` in non-interactive scripts.
+`ghst auth link` requires confirmation before replacing an existing project link; use `--yes` in non-interactive scripts.
 
 ## Command Reference
 
@@ -229,6 +233,7 @@ ghst socialweb status
 ghst socialweb profile
 ghst socialweb notes --json
 ghst socialweb follow @alice@example.com
+ghst socialweb delete https://example.com/.ghost/activitypub/note/1 --yes
 ghst socialweb note --content "Hello fediverse"
 ghst socialweb reply https://example.com/users/alice/statuses/1 --content "Replying from ghst"
 ```
@@ -236,6 +241,7 @@ ghst socialweb reply https://example.com/users/alice/statuses/1 --content "Reply
 Social web auth note:
 - `ghst socialweb` bootstraps a short-lived identity JWT from `/ghost/api/admin/identities/`.
 - That bridge requires an Owner or Administrator staff access token.
+- `ghst socialweb delete` requires confirmation; use `--yes` in non-interactive scripts.
 - Public Ghost post publishing still lives under `ghst post`; `ghst socialweb` is for notes, interactions, profile, feed, and moderation flows.
 
 Ghost analytics filter semantics:
@@ -245,6 +251,9 @@ Ghost analytics filter semantics:
 Ghost range semantics:
 - `stats growth` clips member, MRR, and subscription histories client-side when Ghost only exposes broader source data.
 - `stats post ... growth` clips Ghost's lifetime post-growth history to the selected window.
+
+File output safety:
+- `ghst member export --output`, `ghst stats ... --csv --output`, and `ghst migrate export --output` refuse to overwrite an existing file.
 
 `endpointPath` must stay within the selected Ghost API root. Use resource paths such as `/posts/`
 or canonical Ghost API paths such as `/ghost/api/admin/posts/`.

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -9,12 +9,15 @@ import {
   readProjectConfig,
   readUserConfig,
   resolveConnectionConfig,
+  resolveProjectConfigCwd,
   writeProjectConfig,
   writeUserConfig,
 } from '../lib/config.js';
 import { getGlobalOptions } from '../lib/context.js';
 import { credentialRefForAlias, getCredentialStore } from '../lib/credentials.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
+import { confirm } from '../lib/prompts.js';
+import { isNonInteractive } from '../lib/tty.js';
 
 type PromptFn = (question: string) => Promise<string>;
 type OpenUrlFn = (url: string) => Promise<void>;
@@ -629,6 +632,7 @@ export function registerAuthCommands(program: Command): void {
     .command('logout')
     .description('Remove credentials for one site or all sites')
     .option('--site <alias>', 'Specific site to remove')
+    .option('--yes', 'Skip confirmation when removing all configured sites')
     .action(async (options, command) => {
       const global = getGlobalOptions(command);
       const config = await readUserConfig();
@@ -656,6 +660,23 @@ export function registerAuthCommands(program: Command): void {
         return;
       }
 
+      if (!options.yes) {
+        if (isNonInteractive()) {
+          throw new GhstError('Removing all sites in non-interactive mode requires --yes.', {
+            exitCode: ExitCode.USAGE_ERROR,
+            code: 'USAGE_ERROR',
+          });
+        }
+
+        const ok = await confirm('Remove all configured sites and credentials? [y/N]: ');
+        if (!ok) {
+          throw new GhstError('Operation cancelled.', {
+            exitCode: ExitCode.OPERATION_CANCELLED,
+            code: 'OPERATION_CANCELLED',
+          });
+        }
+      }
+
       for (const site of Object.values(config.sites)) {
         if (site.credentialRef) {
           await store.delete(site.credentialRef).catch(() => undefined);
@@ -671,6 +692,7 @@ export function registerAuthCommands(program: Command): void {
     .command('link')
     .description('Link current project directory to a configured site alias')
     .option('--site <alias>', 'Site alias to link')
+    .option('--yes', 'Skip confirmation when replacing an existing project link')
     .action(async (options, command) => {
       const global = getGlobalOptions(command);
       const config = await readUserConfig();
@@ -683,9 +705,39 @@ export function registerAuthCommands(program: Command): void {
         });
       }
 
-      await writeProjectConfig({
-        site: siteAlias,
-      });
+      const projectConfig = await readProjectConfig();
+      const projectConfigCwd = await resolveProjectConfigCwd();
+      if (projectConfig && projectConfig.site !== siteAlias) {
+        if (!options.yes) {
+          if (isNonInteractive()) {
+            throw new GhstError(
+              'Overwriting an existing project link in non-interactive mode requires --yes.',
+              {
+                exitCode: ExitCode.USAGE_ERROR,
+                code: 'USAGE_ERROR',
+              },
+            );
+          }
+
+          const ok = await confirm(
+            `Relink current directory from '${projectConfig.site}' to '${siteAlias}'? [y/N]: `,
+          );
+          if (!ok) {
+            throw new GhstError('Operation cancelled.', {
+              exitCode: ExitCode.OPERATION_CANCELLED,
+              code: 'OPERATION_CANCELLED',
+            });
+          }
+        }
+      }
+
+      await writeProjectConfig(
+        {
+          ...(projectConfig?.defaults ? { defaults: projectConfig.defaults } : {}),
+          site: siteAlias,
+        },
+        projectConfigCwd,
+      );
 
       console.log(`Linked current directory to '${siteAlias}'.`);
     });

--- a/src/commands/member.ts
+++ b/src/commands/member.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import type { Command } from 'commander';
 import { getGlobalOptions } from '../lib/context.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
+import { assertFileDoesNotExist } from '../lib/file-guards.js';
 import {
   bulkMembers,
   createMember,
@@ -388,6 +389,7 @@ export function registerMemberCommands(program: Command): void {
       });
 
       if (parsed.data.output) {
+        await assertFileDoesNotExist(parsed.data.output);
         await fs.writeFile(parsed.data.output, csv, 'utf8');
 
         if (global.json) {

--- a/src/commands/socialweb.ts
+++ b/src/commands/socialweb.ts
@@ -12,6 +12,7 @@ import {
   printSocialWebThreadHuman,
 } from '../lib/output.js';
 import { parseBooleanFlag, parseInteger } from '../lib/parse.js';
+import { confirm } from '../lib/prompts.js';
 import {
   blockAccount,
   blockDomain,
@@ -46,9 +47,11 @@ import {
   updateSocialWebProfile,
   uploadSocialWebImage,
 } from '../lib/socialweb.js';
+import { isNonInteractive } from '../lib/tty.js';
 import {
   SocialWebBlockDomainInputSchema,
   SocialWebContentInputSchema,
+  SocialWebDeleteInputSchema,
   SocialWebFollowsInputSchema,
   SocialWebHandleActionInputSchema,
   SocialWebIdInputSchema,
@@ -399,12 +402,11 @@ export function registerSocialWebCommands(program: Command): void {
     ['unlike', unlikePost, 'Unlike a post'],
     ['repost', repostPost, 'Repost a post'],
     ['derepost', derepostPost, 'Undo repost on a post'],
-    ['delete', deleteSocialWebPost, 'Delete a post'],
   ] as const) {
     socialweb
       .command(`${entry[0]} <id>`)
       .description(entry[2])
-      .action(async (id: string, _, command) => {
+      .action(async (id: string, _options, command) => {
         const global = getGlobalOptions(command);
         const parsed = SocialWebIdInputSchema.safeParse({ id });
         if (!parsed.success) {
@@ -416,9 +418,48 @@ export function registerSocialWebCommands(program: Command): void {
           printJson(payload, global.jq);
           return;
         }
-        console.log(entry[0] === 'delete' ? 'Deleted post' : 'OK');
+        console.log('OK');
       });
   }
+
+  socialweb
+    .command('delete <id>')
+    .description('Delete a post')
+    .option('--yes', 'Skip confirmation')
+    .action(async (id: string, options, command) => {
+      const global = getGlobalOptions(command);
+      const parsed = SocialWebDeleteInputSchema.safeParse({
+        id,
+        yes: parseBooleanFlag(options.yes),
+      });
+      if (!parsed.success) {
+        throwValidationError(parsed.error);
+      }
+
+      if (!parsed.data.yes) {
+        if (isNonInteractive()) {
+          throw new GhstError('Deleting in non-interactive mode requires --yes.', {
+            code: 'USAGE_ERROR',
+            exitCode: ExitCode.USAGE_ERROR,
+          });
+        }
+
+        const ok = await confirm(`Delete social web post '${parsed.data.id}'? [y/N]: `);
+        if (!ok) {
+          throw new GhstError('Operation cancelled.', {
+            code: 'OPERATION_CANCELLED',
+            exitCode: ExitCode.OPERATION_CANCELLED,
+          });
+        }
+      }
+
+      const payload = await deleteSocialWebPost(global, parsed.data.id);
+      if (global.json) {
+        printJson(payload, global.jq);
+        return;
+      }
+      console.log('Deleted post');
+    });
 
   socialweb
     .command('note')

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import type { Command } from 'commander';
 import { getGlobalOptions } from '../lib/context.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
+import { assertFileDoesNotExist } from '../lib/file-guards.js';
 import {
   formatCsv,
   isJsonMode,
@@ -314,6 +315,7 @@ function postReferrersCsv(payload: StatsPostReferrersReport): string {
 
 async function emitCsv(csv: string, output?: string): Promise<void> {
   if (output) {
+    await assertFileDoesNotExist(output);
     await fs.writeFile(output, `${csv}\n`, 'utf8');
     return;
   }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -169,6 +169,15 @@ async function findProjectConfigPath(cwd = process.cwd()): Promise<string | null
   }
 }
 
+export async function resolveProjectConfigCwd(cwd = process.cwd()): Promise<string> {
+  const configPath = await findProjectConfigPath(cwd);
+  if (!configPath) {
+    return cwd;
+  }
+
+  return path.dirname(path.dirname(configPath));
+}
+
 export async function readUserConfig(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<GhstUserConfig> {

--- a/src/lib/file-guards.ts
+++ b/src/lib/file-guards.ts
@@ -1,0 +1,19 @@
+import fs from 'node:fs/promises';
+import { ExitCode, GhstError } from './errors.js';
+
+export async function assertFileDoesNotExist(filePath: string): Promise<void> {
+  try {
+    await fs.access(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return;
+    }
+
+    throw error;
+  }
+
+  throw new GhstError(`Refusing to overwrite existing file: ${filePath}`, {
+    code: 'USAGE_ERROR',
+    exitCode: ExitCode.USAGE_ERROR,
+  });
+}

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -7,6 +7,7 @@ import MarkdownIt from 'markdown-it';
 import { GhostClient } from './client.js';
 import { resolveConnectionConfig } from './config.js';
 import { ExitCode, GhstError } from './errors.js';
+import { assertFileDoesNotExist } from './file-guards.js';
 import type { GlobalOptions } from './types.js';
 
 interface CsvRow {
@@ -531,6 +532,7 @@ export async function migrateImportCsv(
 export async function migrateExport(global: GlobalOptions, outputPath: string): Promise<string> {
   const client = await getClient(global);
   const data = await client.db.export();
+  await assertFileDoesNotExist(outputPath);
   await fs.writeFile(outputPath, data);
   return outputPath;
 }

--- a/src/schemas/socialweb.ts
+++ b/src/schemas/socialweb.ts
@@ -88,6 +88,11 @@ export const SocialWebIdInputSchema = z.object({
   id: UrlSchema,
 });
 
+export const SocialWebDeleteInputSchema = z.object({
+  id: UrlSchema,
+  yes: z.boolean().optional(),
+});
+
 export const SocialWebBlockDomainInputSchema = z.object({
   url: UrlSchema,
 });

--- a/tests/commands-and-run.test.ts
+++ b/tests/commands-and-run.test.ts
@@ -244,10 +244,11 @@ describe('run + commands', () => {
     await expect(run(['node', 'ghst', 'auth', 'link'])).resolves.toBe(ExitCode.SUCCESS);
     await expect(run(['node', 'ghst', 'auth', 'token'])).resolves.toBe(ExitCode.SUCCESS);
 
+    await expect(run(['node', 'ghst', 'auth', 'logout'])).resolves.toBe(ExitCode.USAGE_ERROR);
     await expect(run(['node', 'ghst', 'auth', 'logout', '--site', 'myblog'])).resolves.toBe(
       ExitCode.SUCCESS,
     );
-    await expect(run(['node', 'ghst', 'auth', 'logout'])).resolves.toBe(ExitCode.SUCCESS);
+    await expect(run(['node', 'ghst', 'auth', 'logout', '--yes'])).resolves.toBe(ExitCode.SUCCESS);
 
     const promptAnswers = ['https://prompted.ghost.io', '', KEY];
     setPromptForTests(async () => promptAnswers.shift() ?? '');
@@ -346,6 +347,74 @@ describe('run + commands', () => {
       sites: ['project', 'active'],
     });
     expect(logSpy.mock.calls.length).toBe(start + 1);
+  });
+
+  test('refuses to overwrite project links and explicit output files', async () => {
+    await loginMyblog();
+    await seedSmokeFixtures();
+
+    await fs.mkdir(path.join(workDir, '.ghst'), { recursive: true });
+    await fs.writeFile(
+      path.join(workDir, '.ghst', 'config.json'),
+      '{"site":"existing","defaults":{"format":"json"}}',
+      'utf8',
+    );
+    await expect(run(['node', 'ghst', 'auth', 'link'])).resolves.toBe(ExitCode.USAGE_ERROR);
+    await expect(run(['node', 'ghst', 'auth', 'link', '--yes'])).resolves.toBe(ExitCode.SUCCESS);
+    await expect(
+      fs.readFile(path.join(workDir, '.ghst', 'config.json'), 'utf8'),
+    ).resolves.toContain('"site": "myblog"');
+    await expect(
+      fs.readFile(path.join(workDir, '.ghst', 'config.json'), 'utf8'),
+    ).resolves.toContain('"format": "json"');
+    await fs.rm(path.join(workDir, '.ghst'), { recursive: true, force: true });
+
+    await fs.writeFile(path.join(workDir, 'members-export.csv'), 'existing\n', 'utf8');
+    await expect(
+      run(['node', 'ghst', 'member', 'export', '--output', './members-export.csv']),
+    ).resolves.toBe(ExitCode.USAGE_ERROR);
+
+    await fs.writeFile(path.join(workDir, 'posts.csv'), 'existing\n', 'utf8');
+    await expect(
+      run(['node', 'ghst', 'stats', 'posts', '--csv', '--output', './posts.csv']),
+    ).resolves.toBe(ExitCode.USAGE_ERROR);
+
+    await fs.writeFile(path.join(workDir, 'export.zip'), 'existing\n', 'utf8');
+    await expect(
+      run(['node', 'ghst', 'migrate', 'export', '--output', './export.zip', '--json']),
+    ).resolves.toBe(ExitCode.USAGE_ERROR);
+  });
+
+  test('updates the discovered project link instead of creating a nested one from a subdirectory', async () => {
+    await loginMyblog();
+    await fs.mkdir(path.join(workDir, '.git'), { recursive: true });
+    await fs.mkdir(path.join(workDir, '.ghst'), { recursive: true });
+    await fs.writeFile(
+      path.join(workDir, '.ghst', 'config.json'),
+      '{"site":"existing","defaults":{"format":"json"}}',
+      'utf8',
+    );
+
+    const nestedDir = path.join(workDir, 'packages', 'cli');
+    await fs.mkdir(nestedDir, { recursive: true });
+
+    const previousCwd = process.cwd();
+    process.chdir(nestedDir);
+    try {
+      await expect(run(['node', 'ghst', 'auth', 'link', '--yes'])).resolves.toBe(ExitCode.SUCCESS);
+    } finally {
+      process.chdir(previousCwd);
+    }
+
+    await expect(
+      fs.readFile(path.join(workDir, '.ghst', 'config.json'), 'utf8'),
+    ).resolves.toContain('"site": "myblog"');
+    await expect(
+      fs.readFile(path.join(workDir, '.ghst', 'config.json'), 'utf8'),
+    ).resolves.toContain('"format": "json"');
+    await expect(fs.stat(path.join(nestedDir, '.ghst', 'config.json'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
   });
 
   test('renders configured domains instead of internal aliases in auth status and list output', async () => {
@@ -2531,6 +2600,30 @@ describe('run + commands', () => {
   test('runs socialweb commands through the identity-token bridge', async () => {
     const logSpy = vi.spyOn(console, 'log');
     await fs.writeFile(path.join(workDir, 'photo.jpg'), 'image');
+    const stdinTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+    const stdoutTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+    await expect(
+      run([
+        'node',
+        'ghst',
+        '--url',
+        'https://myblog.ghost.io',
+        '--staff-token',
+        KEY,
+        'socialweb',
+        'delete',
+        'https://myblog.ghost.io/.ghost/activitypub/note/1',
+        '--json',
+      ]),
+    ).resolves.toBe(ExitCode.USAGE_ERROR);
+    if (stdinTtyDescriptor) {
+      Object.defineProperty(process.stdin, 'isTTY', stdinTtyDescriptor);
+    }
+    if (stdoutTtyDescriptor) {
+      Object.defineProperty(process.stdout, 'isTTY', stdoutTtyDescriptor);
+    }
 
     for (const argv of [
       ['socialweb', 'status', '--json'],
@@ -2552,7 +2645,13 @@ describe('run + commands', () => {
       ['socialweb', 'unlike', 'https://remote.example/posts/1', '--json'],
       ['socialweb', 'repost', 'https://remote.example/posts/1', '--json'],
       ['socialweb', 'derepost', 'https://remote.example/posts/1', '--json'],
-      ['socialweb', 'delete', 'https://myblog.ghost.io/.ghost/activitypub/note/1', '--json'],
+      [
+        'socialweb',
+        'delete',
+        'https://myblog.ghost.io/.ghost/activitypub/note/1',
+        '--yes',
+        '--json',
+      ],
       ['socialweb', 'blocked-accounts', '--limit', '1', '--json'],
       ['socialweb', 'blocked-domains', '--limit', '1', '--json'],
       ['socialweb', 'block', 'https://remote.example/users/alice', '--json'],
@@ -2785,7 +2884,13 @@ describe('run + commands', () => {
       ['socialweb', 'unfollow', '@alice@remote.example', '--json'],
       ['socialweb', 'unlike', 'https://remote.example/posts/1', '--json'],
       ['socialweb', 'derepost', 'https://remote.example/posts/1', '--json'],
-      ['socialweb', 'delete', 'https://myblog.ghost.io/.ghost/activitypub/note/1', '--json'],
+      [
+        'socialweb',
+        'delete',
+        'https://myblog.ghost.io/.ghost/activitypub/note/1',
+        '--yes',
+        '--json',
+      ],
       ['socialweb', 'block', 'https://remote.example/users/alice', '--json'],
       ['socialweb', 'unblock', 'https://remote.example/users/alice', '--json'],
       ['socialweb', 'block-domain', 'https://remote.example', '--json'],


### PR DESCRIPTION
## Summary
- require confirmation or `--yes` for destructive `auth logout`, `auth link`, and `socialweb delete` flows
- refuse to overwrite explicit export/output file paths for member export, stats CSV output, and migrate export
- keep `auth link` updating the discovered project config within the enclosing repo and document the new safety behavior

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`