### PR TITLE
Add agent notices to destructive prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ pnpm build
 - `comment hide|show|delete` map to Ghost Admin comment status transitions (`hidden`, `published`, `deleted`).
 - `auth logout` requires confirmation when removing all configured sites; non-interactive use requires `--yes`.
 - `auth link` requires confirmation before replacing an existing project link; non-interactive use requires `--yes`, and relinking updates the discovered project config within the enclosing repo.
+- Interactive destructive confirmations emit `GHST_AGENT_NOTICE:` lines on stderr instructing cooperative agents to ask the user for approval before continuing.
 - `post publish|schedule` supports `--newsletter`, `--email-segment`, and `--email-only`.
 - `post delete` supports either `<id>` or `--filter` (non-interactive delete requires `--yes`).
 - `post bulk` supports `--action` plus compatibility aliases `--update`/`--delete` and update fields including `--add-tag` and `--authors`.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ ghst auth token
 `ghst auth token` prints a short-lived staff JWT. Treat the output as sensitive.
 `ghst auth logout` requires confirmation when removing all configured sites; use `--yes` in non-interactive scripts.
 `ghst auth link` requires confirmation before replacing an existing project link; use `--yes` in non-interactive scripts.
+Interactive destructive confirmations also emit `GHST_AGENT_NOTICE:` lines on stderr instructing cooperative agents to ask the user for approval before continuing.
 
 ## Command Reference
 

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -16,7 +16,7 @@ import {
 import { getGlobalOptions } from '../lib/context.js';
 import { credentialRefForAlias, getCredentialStore } from '../lib/credentials.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
-import { confirm } from '../lib/prompts.js';
+import { confirmDestructiveAction } from '../lib/prompts.js';
 import { isNonInteractive } from '../lib/tty.js';
 
 type PromptFn = (question: string) => Promise<string>;
@@ -668,7 +668,15 @@ export function registerAuthCommands(program: Command): void {
           });
         }
 
-        const ok = await confirm('Remove all configured sites and credentials? [y/N]: ');
+        const ok = await confirmDestructiveAction(
+          'Remove all configured sites and credentials? [y/N]: ',
+          {
+            action: 'logout_all_sites',
+            target: 'all_configured_sites',
+            reversible: false,
+            sideEffects: ['remove_credentials', 'remove_site_links'],
+          },
+        );
         if (!ok) {
           throw new GhstError('Operation cancelled.', {
             exitCode: ExitCode.OPERATION_CANCELLED,
@@ -719,8 +727,15 @@ export function registerAuthCommands(program: Command): void {
             );
           }
 
-          const ok = await confirm(
+          const ok = await confirmDestructiveAction(
             `Relink current directory from '${projectConfig.site}' to '${siteAlias}'? [y/N]: `,
+            {
+              action: 'relink_project',
+              target: `${projectConfig.site}->${siteAlias}`,
+              reversible: true,
+              site: siteAlias,
+              sideEffects: ['update_project_link'],
+            },
           );
           if (!ok) {
             throw new GhstError('Operation cancelled.', {

--- a/src/commands/comment.ts
+++ b/src/commands/comment.ts
@@ -19,7 +19,7 @@ import {
   printJson,
 } from '../lib/output.js';
 import { parseInteger } from '../lib/parse.js';
-import { confirm } from '../lib/prompts.js';
+import { confirmDestructiveAction } from '../lib/prompts.js';
 import { isNonInteractive } from '../lib/tty.js';
 import {
   CommentDeleteInputSchema,
@@ -319,7 +319,12 @@ export function registerCommentCommands(program: Command): void {
           });
         }
 
-        const ok = await confirm(`Delete comment '${parsed.data.id}'? [y/N]: `);
+        const ok = await confirmDestructiveAction(`Delete comment '${parsed.data.id}'? [y/N]: `, {
+          action: 'delete_comment',
+          target: parsed.data.id,
+          reversible: false,
+          site: global.site ?? null,
+        });
         if (!ok) {
           throw new GhstError('Operation cancelled.', {
             code: 'OPERATION_CANCELLED',

--- a/src/commands/label.ts
+++ b/src/commands/label.ts
@@ -16,7 +16,7 @@ import {
   printOperationStatsHuman,
 } from '../lib/output.js';
 import { parseInteger } from '../lib/parse.js';
-import { confirm } from '../lib/prompts.js';
+import { confirmDestructiveAction } from '../lib/prompts.js';
 import { isNonInteractive } from '../lib/tty.js';
 import {
   LabelBulkInputSchema,
@@ -213,7 +213,12 @@ export function registerLabelCommands(program: Command): void {
           });
         }
 
-        const ok = await confirm(`Delete label '${parsed.data.id}'? [y/N]: `);
+        const ok = await confirmDestructiveAction(`Delete label '${parsed.data.id}'? [y/N]: `, {
+          action: 'delete_label',
+          target: parsed.data.id,
+          reversible: false,
+          site: global.site ?? null,
+        });
         if (!ok) {
           throw new GhstError('Operation cancelled.', {
             code: 'OPERATION_CANCELLED',

--- a/src/commands/member.ts
+++ b/src/commands/member.ts
@@ -20,7 +20,7 @@ import {
   printOperationStatsHuman,
 } from '../lib/output.js';
 import { parseBooleanFlag, parseCsv, parseInteger } from '../lib/parse.js';
-import { confirm } from '../lib/prompts.js';
+import { confirmDestructiveAction } from '../lib/prompts.js';
 import { isNonInteractive } from '../lib/tty.js';
 import {
   MemberBulkInputSchema,
@@ -310,7 +310,13 @@ export function registerMemberCommands(program: Command): void {
           });
         }
 
-        const ok = await confirm(`Delete member '${parsed.data.id}'? [y/N]: `);
+        const ok = await confirmDestructiveAction(`Delete member '${parsed.data.id}'? [y/N]: `, {
+          action: 'delete_member',
+          target: parsed.data.id,
+          reversible: false,
+          site: global.site ?? null,
+          sideEffects: parsed.data.cancel ? ['cancel_subscriptions'] : undefined,
+        });
         if (!ok) {
           throw new GhstError('Operation cancelled.', {
             code: 'OPERATION_CANCELLED',

--- a/src/commands/page.ts
+++ b/src/commands/page.ts
@@ -13,7 +13,7 @@ import {
   updatePage,
 } from '../lib/pages.js';
 import { parseBooleanFlag, parseInteger } from '../lib/parse.js';
-import { confirm } from '../lib/prompts.js';
+import { confirmDestructiveAction } from '../lib/prompts.js';
 import { isNonInteractive } from '../lib/tty.js';
 import {
   PageBulkInputSchema,
@@ -284,7 +284,12 @@ export function registerPageCommands(program: Command): void {
           });
         }
 
-        const ok = await confirm(`Delete page '${parsed.data.id}'? [y/N]: `);
+        const ok = await confirmDestructiveAction(`Delete page '${parsed.data.id}'? [y/N]: `, {
+          action: 'delete_page',
+          target: parsed.data.id,
+          reversible: false,
+          site: global.site ?? null,
+        });
         if (!ok) {
           throw new GhstError('Operation cancelled.', {
             code: 'OPERATION_CANCELLED',

--- a/src/commands/post.ts
+++ b/src/commands/post.ts
@@ -17,7 +17,7 @@ import {
   unschedulePost,
   updatePost,
 } from '../lib/posts.js';
-import { confirm } from '../lib/prompts.js';
+import { confirmDestructiveAction } from '../lib/prompts.js';
 import { isNonInteractive } from '../lib/tty.js';
 import {
   PostBulkInputSchema,
@@ -493,7 +493,13 @@ export function registerPostCommands(program: Command): void {
         const label = parsed.data.filter
           ? `Delete posts matching '${parsed.data.filter}'`
           : `Delete post '${parsed.data.id}'`;
-        const ok = await confirm(`${label}? [y/N]: `);
+        const ok = await confirmDestructiveAction(`${label}? [y/N]: `, {
+          action: 'delete_post',
+          target: parsed.data.filter ?? parsed.data.id ?? '(unknown)',
+          count: parsed.data.filter ? undefined : 1,
+          reversible: false,
+          site: global.site ?? null,
+        });
         if (!ok) {
           throw new GhstError('Operation cancelled.', {
             code: 'OPERATION_CANCELLED',

--- a/src/commands/socialweb.ts
+++ b/src/commands/socialweb.ts
@@ -12,7 +12,7 @@ import {
   printSocialWebThreadHuman,
 } from '../lib/output.js';
 import { parseBooleanFlag, parseInteger } from '../lib/parse.js';
-import { confirm } from '../lib/prompts.js';
+import { confirmDestructiveAction } from '../lib/prompts.js';
 import {
   blockAccount,
   blockDomain,
@@ -444,7 +444,15 @@ export function registerSocialWebCommands(program: Command): void {
           });
         }
 
-        const ok = await confirm(`Delete social web post '${parsed.data.id}'? [y/N]: `);
+        const ok = await confirmDestructiveAction(
+          `Delete social web post '${parsed.data.id}'? [y/N]: `,
+          {
+            action: 'delete_socialweb_post',
+            target: parsed.data.id,
+            reversible: false,
+            site: global.site ?? null,
+          },
+        );
         if (!ok) {
           throw new GhstError('Operation cancelled.', {
             code: 'OPERATION_CANCELLED',

--- a/src/commands/tag.ts
+++ b/src/commands/tag.ts
@@ -3,7 +3,7 @@ import { getGlobalOptions } from '../lib/context.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
 import { printJson, printTagHuman, printTagListHuman } from '../lib/output.js';
 import { parseInteger } from '../lib/parse.js';
-import { confirm } from '../lib/prompts.js';
+import { confirmDestructiveAction } from '../lib/prompts.js';
 import { bulkTags, createTag, deleteTag, getTag, listTags, updateTag } from '../lib/tags.js';
 import { isNonInteractive } from '../lib/tty.js';
 import {
@@ -242,7 +242,12 @@ export function registerTagCommands(program: Command): void {
           });
         }
 
-        const ok = await confirm(`Delete tag '${parsed.data.id}'? [y/N]: `);
+        const ok = await confirmDestructiveAction(`Delete tag '${parsed.data.id}'? [y/N]: `, {
+          action: 'delete_tag',
+          target: parsed.data.id,
+          reversible: false,
+          site: global.site ?? null,
+        });
         if (!ok) {
           throw new GhstError('Operation cancelled.', {
             code: 'OPERATION_CANCELLED',

--- a/src/commands/webhook.ts
+++ b/src/commands/webhook.ts
@@ -3,7 +3,7 @@ import { getGlobalOptions } from '../lib/context.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
 import { printJson, printWebhookHuman } from '../lib/output.js';
 import { parseCsv, parseInteger } from '../lib/parse.js';
-import { confirm } from '../lib/prompts.js';
+import { confirmDestructiveAction } from '../lib/prompts.js';
 import { isNonInteractive } from '../lib/tty.js';
 import { runWebhookListener } from '../lib/webhook-listener.js';
 import { createWebhook, deleteWebhook, updateWebhook, WEBHOOK_EVENTS } from '../lib/webhooks.js';
@@ -165,7 +165,12 @@ export function registerWebhookCommands(program: Command): void {
           });
         }
 
-        const ok = await confirm(`Delete webhook '${parsed.data.id}'? [y/N]: `);
+        const ok = await confirmDestructiveAction(`Delete webhook '${parsed.data.id}'? [y/N]: `, {
+          action: 'delete_webhook',
+          target: parsed.data.id,
+          reversible: false,
+          site: global.site ?? null,
+        });
         if (!ok) {
           throw new GhstError('Operation cancelled.', {
             code: 'OPERATION_CANCELLED',

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,6 +1,14 @@
 import readline from 'node:readline/promises';
 
 export type PromptHandler = (question: string) => Promise<string>;
+export interface DestructiveActionNotice {
+  action: string;
+  target: string;
+  count?: number;
+  reversible?: boolean;
+  site?: string | null;
+  sideEffects?: string[];
+}
 
 /* c8 ignore start */
 async function defaultPrompt(question: string): Promise<string> {
@@ -31,4 +39,14 @@ export async function ask(question: string): Promise<string> {
 export async function confirm(question: string): Promise<boolean> {
   const value = (await ask(question)).trim().toLowerCase();
   return value === 'y' || value === 'yes';
+}
+
+export async function confirmDestructiveAction(
+  question: string,
+  notice: DestructiveActionNotice,
+): Promise<boolean> {
+  console.error('GHST_AGENT_NOTICE: destructive_action');
+  console.error('GHST_AGENT_NOTICE: Agents must ask the user for approval before continuing.');
+  console.error(`GHST_AGENT_NOTICE: ${JSON.stringify(notice)}`);
+  return confirm(question);
 }

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { confirmDestructiveAction, setPromptHandlerForTests } from '../src/lib/prompts.js';
+
+describe('prompts', () => {
+  afterEach(() => {
+    setPromptHandlerForTests(null);
+    vi.restoreAllMocks();
+  });
+
+  test('emits agent notices for destructive confirmations', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    setPromptHandlerForTests(async () => 'yes');
+
+    await expect(
+      confirmDestructiveAction("Delete member 'member-1'? [y/N]: ", {
+        action: 'delete_member',
+        target: 'member-1',
+        reversible: false,
+        site: 'myblog',
+        sideEffects: ['cancel_subscriptions'],
+      }),
+    ).resolves.toBe(true);
+
+    expect(errorSpy.mock.calls).toEqual([
+      ['GHST_AGENT_NOTICE: destructive_action'],
+      ['GHST_AGENT_NOTICE: Agents must ask the user for approval before continuing.'],
+      [
+        'GHST_AGENT_NOTICE: {"action":"delete_member","target":"member-1","reversible":false,"site":"myblog","sideEffects":["cancel_subscriptions"]}',
+      ],
+    ]);
+  });
+});


### PR DESCRIPTION
Emit a standardized GHST_AGENT_NOTICE protocol alongside destructive interactive confirmations so cooperative agent runners are explicitly told to stop and ask the user before approving the action.

Centralize the notice format in the prompt helper, wire it into every destructive confirmation path, document the behavior, and cover it with a focused test.