### PR TITLE
Update to support member.status = `gift`

### DIFF
--- a/src/commands/member.ts
+++ b/src/commands/member.ts
@@ -66,7 +66,7 @@ export function registerMemberCommands(program: Command): void {
     .option('--limit <numberOrAll>', 'Number of members per page or "all"')
     .option('--page <number>', 'Page number')
     .option('--filter <nql>', 'NQL filter')
-    .option('--status <status>', 'Member status (free|paid|comped)')
+    .option('--status <status>', 'Member status (free|paid|comped|gift)')
     .option('--search <term>', 'Search term')
     .option('--include <relations>', 'Include relationships')
     .option('--fields <fields>', 'Select output fields')

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -607,7 +607,8 @@ function normalizeMembersSeries(rows: Record<string, unknown>[]): StatsSeriesPoi
         row.count ??
         getNumber(row.free_members ?? row.free) +
           getNumber(row.paid_members ?? row.paid) +
-          getNumber(row.comped),
+          getNumber(row.comped) +
+          getNumber(row.gift),
     ),
     mrr: null,
     subscriptions: null,

--- a/src/schemas/member.ts
+++ b/src/schemas/member.ts
@@ -7,7 +7,7 @@ export const MemberListInputSchema = z.object({
   limit: z.union([z.number().int().positive().max(100), z.literal('all')]).optional(),
   page: z.number().int().positive().optional(),
   filter: z.string().optional(),
-  status: z.enum(['free', 'paid', 'comped']).optional(),
+  status: z.enum(['free', 'paid', 'comped', 'gift']).optional(),
   search: z.string().optional(),
   include: z.string().optional(),
   fields: z.string().optional(),

--- a/tests/commands-and-run.test.ts
+++ b/tests/commands-and-run.test.ts
@@ -1186,6 +1186,9 @@ describe('run + commands', () => {
     await expect(run(['node', 'ghst', 'member', 'list', '--status', 'paid'])).resolves.toBe(
       ExitCode.SUCCESS,
     );
+    await expect(run(['node', 'ghst', 'member', 'list', '--status', 'gift'])).resolves.toBe(
+      ExitCode.SUCCESS,
+    );
     await expect(run(['node', 'ghst', 'member', 'get', fixtureIds.memberId])).resolves.toBe(
       ExitCode.SUCCESS,
     );

--- a/tests/lib-stats.test.ts
+++ b/tests/lib-stats.test.ts
@@ -245,6 +245,31 @@ describe('stats library', () => {
     ]);
   });
 
+  test('includes gift members in the total_members fallback when the row carries a gift bucket', async () => {
+    installGhostFixtureFetchMock({
+      onRequest: ({ pathname, method }) => {
+        if (pathname.endsWith('/ghost/api/admin/stats/member_count/') && method === 'GET') {
+          return new Response(
+            JSON.stringify({
+              stats: [{ date: '2026-02-06', free: 100, paid: 5, comped: 2, gift: 3 }],
+              meta: { totals: { free: 100, paid: 5, comped: 2, gift: 3 } },
+            }),
+            {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            },
+          );
+        }
+
+        return undefined;
+      },
+    });
+
+    const payload = await getStatsGrowth({}, { from: '2026-02-06', to: '2026-02-06' });
+
+    expect(payload.members[0]?.total_members).toBe(110);
+  });
+
   test('clips growth histories client-side to the selected range', async () => {
     installGhostFixtureFetchMock();
 

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -19,6 +19,7 @@ import {
   MemberBulkInputSchema,
   MemberCreateInputSchema,
   MemberGetInputSchema,
+  MemberListInputSchema,
   MemberUpdateInputSchema,
 } from '../src/schemas/member.js';
 import {
@@ -220,6 +221,13 @@ describe('member schemas', () => {
       '--tier',
     );
     expectInvalid(MemberUpdateInputSchema, { id: 'member-1' }, 'Provide at least one update field');
+  });
+
+  test('accepts gift alongside the existing member statuses on list input', () => {
+    for (const status of ['free', 'paid', 'comped', 'gift'] as const) {
+      expectValid<{ status?: string }>(MemberListInputSchema, { status });
+    }
+    expectInvalid(MemberListInputSchema, { status: 'unknown' });
   });
 
   test('enforce member selectors and bulk destructive safeguards', () => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3594

Ghost added a new `gift` value to `member.status` (alongside `free`,`paid`, and `comped`) to represent members with a gift subscription. This change extends the CLI to recognise it:

- Allow `--status gift` on `ghst member list` (Zod schema + help text).
- Sum `row.gift` in `normalizeMembersSeries`'s `total_members` fallback, so gift members aren't silently dropped from totals when Ghost's `/stats/member_count/` response omits a precomputed total. Verified against Ghost 6.36, which already emits a `gift` bucket in member count rows and `meta.totals`.

Audience filtering (`stats --audience`) is intentionally unchanged: Ghost's Tinybird pipes only accept `undefined|free|paid` as inputs and fold gift sessions into `paid` server-side (per TryGhost/Ghost#27614), so no client change is needed there