### PR TITLE
Require destructive action opt-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,11 +106,12 @@ pnpm build
 - `comment list` defaults to site-wide admin moderation semantics and includes replies unless `--top-level-only` is passed.
 - `comment get` uses Ghost Admin's moderation read include set, and `comment thread` mirrors the Admin moderation sidebar by combining the selected comment read with the filtered thread query.
 - `comment hide|show|delete` map to Ghost Admin comment status transitions (`hidden`, `published`, `deleted`).
-- `auth logout` requires confirmation when removing all configured sites; non-interactive use requires `--yes`.
-- `auth link` requires confirmation before replacing an existing project link; non-interactive use requires `--yes`, and relinking updates the discovered project config within the enclosing repo.
+- Destructive commands require the global `--enable-destructive-actions` flag; `--yes` only skips confirmation where confirmation is still required.
+- `auth logout` requires `--enable-destructive-actions` when removing configured sites and confirmation when removing all configured sites; non-interactive all-site removal also requires `--yes`.
+- `auth link` requires `--enable-destructive-actions` and confirmation before replacing an existing project link; non-interactive use requires `--yes`, and relinking updates the discovered project config within the enclosing repo.
 - Interactive destructive confirmations emit `GHST_AGENT_NOTICE:` lines on stderr instructing cooperative agents to ask the user for approval before continuing.
 - `post publish|schedule` supports `--newsletter`, `--email-segment`, and `--email-only`.
-- `post delete` supports either `<id>` or `--filter` (non-interactive delete requires `--yes`).
+- `post delete` supports either `<id>` or `--filter` (requires `--enable-destructive-actions`; non-interactive delete also requires `--yes`).
 - `post bulk` supports `--action` plus compatibility aliases `--update`/`--delete` and update fields including `--add-tag` and `--authors`.
 - `member list --status` composes with `--filter`.
 - `member export --output`, `stats ... --csv --output`, and `migrate export --output` refuse to overwrite an existing file.
@@ -122,7 +123,7 @@ pnpm build
 - `stats web` and `stats post ... web` use Ghost Admin stats routes where available, plus analytics reads for datasets Ghost does not wrap directly.
 - `socialweb` uses the existing staff-token Admin API flow to mint a short-lived identity JWT from `/ghost/api/admin/identities/`, then uses that bearer token against `/.ghost/activitypub/v1/*`.
 - `socialweb` requires an Owner/Admin staff token and is limited to Ghost's staff-authenticated social web tooling; neither the CLI nor MCP expose public federation endpoints.
-- `socialweb delete` requires confirmation; non-interactive use requires `--yes`.
+- `socialweb delete` requires `--enable-destructive-actions` and confirmation; non-interactive use also requires `--yes`.
 - `stats growth` clips broader Ghost member/MRR/subscription histories client-side to the selected window when upstream endpoints cannot express the full range.
 - `stats post ... growth` clips Ghost lifetime post-growth history client-side to the selected window.
 - Ghost analytics semantics: `source` and `utm_*` filters are session-scoped, while post/member-status filters are hit-scoped.
@@ -130,6 +131,7 @@ pnpm build
 - MCP now exposes first-class comment moderation tools via the `comments` tool group, including list/get/thread/replies/likes/reports/hide/show/delete.
 - MCP now exposes first-class social web tools via the `socialweb` tool group, covering status/profile/feed/interaction/moderation/upload flows.
 - `api [endpointPath]` only accepts resource-relative paths or canonical Ghost API paths within the selected API root.
+- `api [endpointPath]` requires `--enable-destructive-actions` for non-read HTTP methods.
 - `mcp http` requires `--unsafe-public-bind` for non-loopback hosts and `--cors-origin` accepts one exact origin only.
 - MCP includes dedicated tools such as `ghost_post_schedule`, `ghost_image_upload`, `ghost_member_import`, `ghost_newsletter_list`, `ghost_tier_list`, `ghost_offer_list`, `ghost_theme_upload`, and `ghost_webhook_create`.
 

--- a/README.md
+++ b/README.md
@@ -109,14 +109,15 @@ Site/profile management:
 ghst auth list
 ghst auth switch <site-alias>
 ghst auth link --site <site-alias>
-ghst auth link --site <site-alias> --yes
-ghst auth logout --yes
+ghst --enable-destructive-actions auth link --site <site-alias> --yes
+ghst --enable-destructive-actions auth logout --yes
 ghst auth token
 ```
 
 `ghst auth token` prints a short-lived staff JWT. Treat the output as sensitive.
-`ghst auth logout` requires confirmation when removing all configured sites; use `--yes` in non-interactive scripts.
-`ghst auth link` requires confirmation before replacing an existing project link; use `--yes` in non-interactive scripts.
+Destructive commands require `--enable-destructive-actions`; use `--yes` in non-interactive scripts when a destructive command also asks for confirmation.
+`ghst auth logout` requires confirmation when removing all configured sites.
+`ghst auth link` requires confirmation before replacing an existing project link.
 Interactive destructive confirmations also emit `GHST_AGENT_NOTICE:` lines on stderr instructing cooperative agents to ask the user for approval before continuing.
 
 ## Command Reference
@@ -155,6 +156,7 @@ Interactive destructive confirmations also emit `GHST_AGENT_NOTICE:` lines on st
 | `--jq <filter>` | Apply jq-style extraction to JSON output |
 | `--site <alias>` | Use configured site alias |
 | `--url <url>` + `--staff-token <token>` | Use direct credentials for this invocation |
+| `--enable-destructive-actions` | Allow destructive operations such as deletes |
 | `--debug [level]` | Enable debug output |
 | `--no-color` | Disable color output |
 
@@ -172,7 +174,7 @@ Bulk updates:
 ```bash
 ghst post bulk --filter "status:draft" --update --add-tag release-notes --authors editor@example.com
 ghst member bulk --update --filter "status:free" --labels "trial,needs-follow-up"
-ghst label bulk --filter "name:'legacy'" --action delete --yes
+ghst --enable-destructive-actions label bulk --filter "name:'legacy'" --action delete --yes
 ```
 
 Comment moderation:
@@ -183,7 +185,7 @@ ghst comment thread <comment-id>
 ghst comment replies <comment-id>
 ghst comment hide <comment-id>
 ghst comment show <comment-id>
-ghst comment delete <comment-id> --yes
+ghst --enable-destructive-actions comment delete <comment-id> --yes
 ```
 
 Scheduling:
@@ -212,7 +214,7 @@ Direct API calls:
 
 ```bash
 ghst api /posts/ --paginate --include-headers
-ghst api /settings/ -X PUT -f settings[0].key=title -f settings[0].value="New title"
+ghst --enable-destructive-actions api /settings/ -X PUT -f settings[0].key=title -f settings[0].value="New title"
 ```
 
 Analytics reporting:
@@ -234,7 +236,7 @@ ghst socialweb status
 ghst socialweb profile
 ghst socialweb notes --json
 ghst socialweb follow @alice@example.com
-ghst socialweb delete https://example.com/.ghost/activitypub/note/1 --yes
+ghst --enable-destructive-actions socialweb delete https://example.com/.ghost/activitypub/note/1 --yes
 ghst socialweb note --content "Hello fediverse"
 ghst socialweb reply https://example.com/users/alice/statuses/1 --content "Replying from ghst"
 ```
@@ -242,7 +244,7 @@ ghst socialweb reply https://example.com/users/alice/statuses/1 --content "Reply
 Social web auth note:
 - `ghst socialweb` bootstraps a short-lived identity JWT from `/ghost/api/admin/identities/`.
 - That bridge requires an Owner or Administrator staff access token.
-- `ghst socialweb delete` requires confirmation; use `--yes` in non-interactive scripts.
+- `ghst socialweb delete` requires `--enable-destructive-actions` and confirmation; use `--yes` in non-interactive scripts.
 - Public Ghost post publishing still lives under `ghst post`; `ghst socialweb` is for notes, interactions, profile, feed, and moderation flows.
 
 Ghost analytics filter semantics:
@@ -299,6 +301,8 @@ JSON + jq-style extraction:
 ghst post list --json
 ghst post list --json --jq '.posts[].title'
 ```
+
+Raw `ghst api` requests using non-read HTTP methods also require `--enable-destructive-actions`.
 
 Common machine-safe practices:
 

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -4,6 +4,10 @@ import { normalizeGhostApiPath } from '../lib/api-path.js';
 import { GhostClient, type GhostResponseWithMeta } from '../lib/client.js';
 import { resolveConnectionConfig } from '../lib/config.js';
 import { getGlobalOptions } from '../lib/context.js';
+import {
+  assertDestructiveActionsEnabled,
+  isReadOnlyHttpMethod,
+} from '../lib/destructive-actions.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
 import { printJson } from '../lib/output.js';
 import { parseQueryPairs } from '../lib/parse.js';
@@ -202,6 +206,10 @@ export function registerApiCommands(program: Command): void {
       const normalizedEndpointPath = normalizeGhostApiPath(endpointPath, requestApi);
 
       const global = getGlobalOptions(command);
+      if (!isReadOnlyHttpMethod(options.method)) {
+        assertDestructiveActionsEnabled(global, 'raw API write request');
+      }
+
       const connection = await resolveConnectionConfig(global);
       const client = new GhostClient({
         url: connection.url,

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -15,6 +15,7 @@ import {
 } from '../lib/config.js';
 import { getGlobalOptions } from '../lib/context.js';
 import { credentialRefForAlias, getCredentialStore } from '../lib/credentials.js';
+import { assertDestructiveActionsEnabled } from '../lib/destructive-actions.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
 import { confirmDestructiveAction } from '../lib/prompts.js';
 import { isNonInteractive } from '../lib/tty.js';
@@ -648,6 +649,8 @@ export function registerAuthCommands(program: Command): void {
           });
         }
 
+        assertDestructiveActionsEnabled(global, 'logout site');
+
         if (site.credentialRef) {
           await store.delete(site.credentialRef).catch(() => undefined);
         }
@@ -659,6 +662,8 @@ export function registerAuthCommands(program: Command): void {
         console.log(`Removed site '${targetSite}'.`);
         return;
       }
+
+      assertDestructiveActionsEnabled(global, 'logout all sites');
 
       if (!options.yes) {
         if (isNonInteractive()) {
@@ -716,6 +721,8 @@ export function registerAuthCommands(program: Command): void {
       const projectConfig = await readProjectConfig();
       const projectConfigCwd = await resolveProjectConfigCwd();
       if (projectConfig && projectConfig.site !== siteAlias) {
+        assertDestructiveActionsEnabled(global, 'replace project link');
+
         if (!options.yes) {
           if (isNonInteractive()) {
             throw new GhstError(

--- a/src/commands/comment.ts
+++ b/src/commands/comment.ts
@@ -9,6 +9,7 @@ import {
   setCommentStatus,
 } from '../lib/comments.js';
 import { getGlobalOptions } from '../lib/context.js';
+import { assertDestructiveActionsEnabled } from '../lib/destructive-actions.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
 import {
   printCommentHuman,
@@ -310,6 +311,8 @@ export function registerCommentCommands(program: Command): void {
       if (!parsed.success) {
         throwValidationError(parsed.error);
       }
+
+      assertDestructiveActionsEnabled(global, 'delete comment');
 
       if (!parsed.data.yes) {
         if (isNonInteractive()) {

--- a/src/commands/label.ts
+++ b/src/commands/label.ts
@@ -1,5 +1,6 @@
 import type { Command } from 'commander';
 import { getGlobalOptions } from '../lib/context.js';
+import { assertDestructiveActionsEnabled } from '../lib/destructive-actions.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
 import {
   bulkLabels,
@@ -205,6 +206,8 @@ export function registerLabelCommands(program: Command): void {
         throwValidationError(parsed.error);
       }
 
+      assertDestructiveActionsEnabled(global, 'delete label');
+
       if (!parsed.data.yes) {
         if (isNonInteractive()) {
           throw new GhstError('Deleting in non-interactive mode requires --yes.', {
@@ -255,6 +258,10 @@ export function registerLabelCommands(program: Command): void {
 
       if (!parsed.success) {
         throwValidationError(parsed.error);
+      }
+
+      if (parsed.data.action === 'delete') {
+        assertDestructiveActionsEnabled(global, 'bulk delete labels');
       }
 
       const payload = await bulkLabels(global, {

--- a/src/commands/member.ts
+++ b/src/commands/member.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import type { Command } from 'commander';
 import { getGlobalOptions } from '../lib/context.js';
+import { assertDestructiveActionsEnabled } from '../lib/destructive-actions.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
 import { assertFileDoesNotExist } from '../lib/file-guards.js';
 import {
@@ -302,6 +303,8 @@ export function registerMemberCommands(program: Command): void {
         throwValidationError(parsed.error);
       }
 
+      assertDestructiveActionsEnabled(global, 'delete member');
+
       if (!parsed.data.yes) {
         if (isNonInteractive()) {
           throw new GhstError('Deleting in non-interactive mode requires --yes.', {
@@ -453,6 +456,10 @@ export function registerMemberCommands(program: Command): void {
         : parsed.data.delete
           ? 'delete'
           : parsed.data.action;
+      if (resolvedAction === 'delete') {
+        assertDestructiveActionsEnabled(global, 'bulk delete members');
+      }
+
       const payload = await bulkMembers(global, {
         action: (resolvedAction ?? 'unsubscribe') as
           | 'unsubscribe'

--- a/src/commands/page.ts
+++ b/src/commands/page.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import type { Command } from 'commander';
 import { getGlobalOptions } from '../lib/context.js';
+import { assertDestructiveActionsEnabled } from '../lib/destructive-actions.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
 import { printJson, printPageHuman, printPageListHuman } from '../lib/output.js';
 import {
@@ -276,6 +277,8 @@ export function registerPageCommands(program: Command): void {
         throwValidationError(parsed.error);
       }
 
+      assertDestructiveActionsEnabled(global, 'delete page');
+
       if (!parsed.data.yes) {
         if (isNonInteractive()) {
           throw new GhstError('Deleting in non-interactive mode requires --yes.', {
@@ -345,6 +348,10 @@ export function registerPageCommands(program: Command): void {
 
       if (!parsed.success) {
         throwValidationError(parsed.error);
+      }
+
+      if (parsed.data.action === 'delete') {
+        assertDestructiveActionsEnabled(global, 'bulk delete pages');
       }
 
       const payload = await bulkPages(global, {

--- a/src/commands/post.ts
+++ b/src/commands/post.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import type { Command } from 'commander';
 import MarkdownIt from 'markdown-it';
 import { getGlobalOptions } from '../lib/context.js';
+import { assertDestructiveActionsEnabled } from '../lib/destructive-actions.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
 import { printJson, printPostHuman, printPostListHuman } from '../lib/output.js';
 import { parseBooleanFlag, parseCsv, parseInteger } from '../lib/parse.js';
@@ -482,6 +483,8 @@ export function registerPostCommands(program: Command): void {
         throwValidationError(parsed.error);
       }
 
+      assertDestructiveActionsEnabled(global, 'delete post');
+
       if (!parsed.data.yes) {
         if (isNonInteractive()) {
           throw new GhstError('Deleting in non-interactive mode requires --yes.', {
@@ -672,6 +675,10 @@ export function registerPostCommands(program: Command): void {
       }
 
       const action = parsed.data.action ?? (parsed.data.delete ? 'delete' : 'update');
+      if (action === 'delete') {
+        assertDestructiveActionsEnabled(global, 'bulk delete posts');
+      }
+
       const payload = await bulkPosts(global, {
         filter: parsed.data.filter,
         delete: action === 'delete',

--- a/src/commands/socialweb.ts
+++ b/src/commands/socialweb.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import type { Command } from 'commander';
 import { getGlobalOptions } from '../lib/context.js';
+import { assertDestructiveActionsEnabled } from '../lib/destructive-actions.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
 import {
   printJson,
@@ -435,6 +436,8 @@ export function registerSocialWebCommands(program: Command): void {
       if (!parsed.success) {
         throwValidationError(parsed.error);
       }
+
+      assertDestructiveActionsEnabled(global, 'delete social web post');
 
       if (!parsed.data.yes) {
         if (isNonInteractive()) {

--- a/src/commands/tag.ts
+++ b/src/commands/tag.ts
@@ -1,5 +1,6 @@
 import type { Command } from 'commander';
 import { getGlobalOptions } from '../lib/context.js';
+import { assertDestructiveActionsEnabled } from '../lib/destructive-actions.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
 import { printJson, printTagHuman, printTagListHuman } from '../lib/output.js';
 import { parseInteger } from '../lib/parse.js';
@@ -234,6 +235,8 @@ export function registerTagCommands(program: Command): void {
         throwValidationError(parsed.error);
       }
 
+      assertDestructiveActionsEnabled(global, 'delete tag');
+
       if (!parsed.data.yes) {
         if (isNonInteractive()) {
           throw new GhstError('Deleting in non-interactive mode requires --yes.', {
@@ -284,6 +287,10 @@ export function registerTagCommands(program: Command): void {
 
       if (!parsed.success) {
         throwValidationError(parsed.error);
+      }
+
+      if (parsed.data.action === 'delete') {
+        assertDestructiveActionsEnabled(global, 'bulk delete tags');
       }
 
       const payload = await bulkTags(global, {

--- a/src/commands/webhook.ts
+++ b/src/commands/webhook.ts
@@ -1,5 +1,6 @@
 import type { Command } from 'commander';
 import { getGlobalOptions } from '../lib/context.js';
+import { assertDestructiveActionsEnabled } from '../lib/destructive-actions.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
 import { printJson, printWebhookHuman } from '../lib/output.js';
 import { parseCsv, parseInteger } from '../lib/parse.js';
@@ -156,6 +157,8 @@ export function registerWebhookCommands(program: Command): void {
       if (!parsed.success) {
         throwValidationError(parsed.error);
       }
+
+      assertDestructiveActionsEnabled(global, 'delete webhook');
 
       if (!parsed.data.yes) {
         if (isNonInteractive()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export function buildProgram(): Command {
     .option('--site <site>', 'Configured site alias')
     .option('--url <url>', 'Ghost site URL override')
     .option('--staff-token <token>', 'Ghost staff access token override')
+    .option('--enable-destructive-actions', 'Allow destructive operations such as deletes')
     .option('--debug [level]', 'Enable debug output')
     .option('--no-color', 'Disable color output');
 

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -11,6 +11,7 @@ export function getGlobalOptions(command: Command): GlobalOptions {
     site: options.site,
     url: options.url,
     staffToken: options.staffToken,
+    enableDestructiveActions: options.enableDestructiveActions,
     debug: options.debug,
     color: options.color !== false && !noColorFromEnv,
   };

--- a/src/lib/destructive-actions.ts
+++ b/src/lib/destructive-actions.ts
@@ -1,0 +1,24 @@
+import { ExitCode, GhstError } from './errors.js';
+import type { GlobalOptions } from './types.js';
+
+export function assertDestructiveActionsEnabled(
+  global: GlobalOptions,
+  action = 'this operation',
+): void {
+  if (global.enableDestructiveActions) {
+    return;
+  }
+
+  throw new GhstError(
+    `Destructive actions are disabled for ${action}. Re-run with --enable-destructive-actions to continue.`,
+    {
+      code: 'DESTRUCTIVE_ACTIONS_DISABLED',
+      exitCode: ExitCode.USAGE_ERROR,
+    },
+  );
+}
+
+export function isReadOnlyHttpMethod(method: string | undefined): boolean {
+  const normalized = (method ?? 'GET').toUpperCase();
+  return normalized === 'GET' || normalized === 'HEAD' || normalized === 'OPTIONS';
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,7 @@ export interface GlobalOptions {
   site?: string;
   url?: string;
   staffToken?: string;
+  enableDestructiveActions?: boolean;
   debug?: string | boolean;
   color?: boolean;
 }

--- a/src/mcp/tools/core.ts
+++ b/src/mcp/tools/core.ts
@@ -12,6 +12,10 @@ import {
   setCommentStatus,
 } from '../../lib/comments.js';
 import { resolveConnectionConfig } from '../../lib/config.js';
+import {
+  assertDestructiveActionsEnabled,
+  isReadOnlyHttpMethod,
+} from '../../lib/destructive-actions.js';
 import { uploadImage } from '../../lib/images.js';
 import {
   createMember,
@@ -366,6 +370,10 @@ async function callApi(
     contentApi?: boolean;
   },
 ): Promise<Record<string, unknown>> {
+  if (!isReadOnlyHttpMethod(options.method)) {
+    assertDestructiveActionsEnabled(global, 'raw API write request');
+  }
+
   const connection = await resolveConnectionConfig(global);
   const client = new GhostClient({
     url: connection.url,
@@ -505,6 +513,7 @@ export function registerCoreTools(
         }),
       },
       async (args) => {
+        assertDestructiveActionsEnabled(global, 'delete post');
         const payload = await deletePost(global, args.id);
         return toolResult(payload);
       },
@@ -676,6 +685,7 @@ export function registerCoreTools(
         }),
       },
       async (args) => {
+        assertDestructiveActionsEnabled(global, 'delete page');
         const payload = await deletePage(global, args.id);
         return toolResult(payload);
       },
@@ -759,7 +769,10 @@ export function registerCoreTools(
           confirm: z.literal(true),
         }),
       },
-      async (args) => toolResult(await deleteTag(global, args.id)),
+      async (args) => {
+        assertDestructiveActionsEnabled(global, 'delete tag');
+        return toolResult(await deleteTag(global, args.id));
+      },
     );
   }
 
@@ -851,7 +864,10 @@ export function registerCoreTools(
           confirm: z.literal(true),
         }),
       },
-      async (args) => toolResult(await deleteMember(global, args.id)),
+      async (args) => {
+        assertDestructiveActionsEnabled(global, 'delete member');
+        return toolResult(await deleteMember(global, args.id));
+      },
     );
 
     server.registerTool(
@@ -1064,7 +1080,10 @@ export function registerCoreTools(
           confirm: z.literal(true),
         }),
       },
-      async (args) => toolResult(await setCommentStatus(global, args.id, 'deleted')),
+      async (args) => {
+        assertDestructiveActionsEnabled(global, 'delete comment');
+        return toolResult(await setCommentStatus(global, args.id, 'deleted'));
+      },
     );
   }
 
@@ -1479,9 +1498,13 @@ export function registerCoreTools(
         description: 'Delete a social web post authored by the current account.',
         inputSchema: z.object({
           id: socialWebUrlSchema,
+          confirm: z.literal(true),
         }),
       },
-      async (args) => toolResult(await deleteSocialWebPost(global, args.id)),
+      async (args) => {
+        assertDestructiveActionsEnabled(global, 'delete social web post');
+        return toolResult(await deleteSocialWebPost(global, args.id));
+      },
     );
 
     server.registerTool(

--- a/tests/api-command-contracts.test.ts
+++ b/tests/api-command-contracts.test.ts
@@ -79,6 +79,7 @@ describe('api command contracts', () => {
       run([
         'node',
         'ghst',
+        '--enable-destructive-actions',
         'api',
         '/posts/',
         '--method',

--- a/tests/commands-and-run.test.ts
+++ b/tests/commands-and-run.test.ts
@@ -246,10 +246,12 @@ describe('run + commands', () => {
     await expect(run(['node', 'ghst', 'auth', 'token'])).resolves.toBe(ExitCode.SUCCESS);
 
     await expect(run(['node', 'ghst', 'auth', 'logout'])).resolves.toBe(ExitCode.USAGE_ERROR);
-    await expect(run(['node', 'ghst', 'auth', 'logout', '--site', 'myblog'])).resolves.toBe(
-      ExitCode.SUCCESS,
-    );
-    await expect(run(['node', 'ghst', 'auth', 'logout', '--yes'])).resolves.toBe(ExitCode.SUCCESS);
+    await expect(
+      run(['node', 'ghst', '--enable-destructive-actions', 'auth', 'logout', '--site', 'myblog']),
+    ).resolves.toBe(ExitCode.SUCCESS);
+    await expect(
+      run(['node', 'ghst', '--enable-destructive-actions', 'auth', 'logout', '--yes']),
+    ).resolves.toBe(ExitCode.SUCCESS);
 
     const promptAnswers = ['https://prompted.ghost.io', '', KEY];
     setPromptForTests(async () => promptAnswers.shift() ?? '');
@@ -361,7 +363,9 @@ describe('run + commands', () => {
       'utf8',
     );
     await expect(run(['node', 'ghst', 'auth', 'link'])).resolves.toBe(ExitCode.USAGE_ERROR);
-    await expect(run(['node', 'ghst', 'auth', 'link', '--yes'])).resolves.toBe(ExitCode.SUCCESS);
+    await expect(
+      run(['node', 'ghst', '--enable-destructive-actions', 'auth', 'link', '--yes']),
+    ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
       fs.readFile(path.join(workDir, '.ghst', 'config.json'), 'utf8'),
     ).resolves.toContain('"site": "myblog"');
@@ -402,7 +406,9 @@ describe('run + commands', () => {
     const previousCwd = process.cwd();
     process.chdir(nestedDir);
     try {
-      await expect(run(['node', 'ghst', 'auth', 'link', '--yes'])).resolves.toBe(ExitCode.SUCCESS);
+      await expect(
+        run(['node', 'ghst', '--enable-destructive-actions', 'auth', 'link', '--yes']),
+      ).resolves.toBe(ExitCode.SUCCESS);
     } finally {
       process.chdir(previousCwd);
     }
@@ -1027,6 +1033,7 @@ describe('run + commands', () => {
       run([
         'node',
         'ghst',
+        '--enable-destructive-actions',
         'post',
         'bulk',
         '--filter',
@@ -1045,6 +1052,7 @@ describe('run + commands', () => {
       run([
         'node',
         'ghst',
+        '--enable-destructive-actions',
         'post',
         'bulk',
         '--filter',
@@ -1055,7 +1063,17 @@ describe('run + commands', () => {
       ]),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
-      run(['node', 'ghst', 'post', 'delete', '--filter', 'status:draft', '--yes', '--json']),
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
+        'post',
+        'delete',
+        '--filter',
+        'status:draft',
+        '--yes',
+        '--json',
+      ]),
     ).resolves.toBe(ExitCode.SUCCESS);
 
     const stdinTty = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
@@ -1063,13 +1081,13 @@ describe('run + commands', () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
     Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
     setPromptHandlerForTests(async () => 'no');
-    await expect(run(['node', 'ghst', 'post', 'delete', fixtureIds.postId])).resolves.toBe(
-      ExitCode.OPERATION_CANCELLED,
-    );
+    await expect(
+      run(['node', 'ghst', '--enable-destructive-actions', 'post', 'delete', fixtureIds.postId]),
+    ).resolves.toBe(ExitCode.OPERATION_CANCELLED);
     setPromptHandlerForTests(async () => 'yes');
-    await expect(run(['node', 'ghst', 'post', 'delete', fixtureIds.postId])).resolves.toBe(
-      ExitCode.SUCCESS,
-    );
+    await expect(
+      run(['node', 'ghst', '--enable-destructive-actions', 'post', 'delete', fixtureIds.postId]),
+    ).resolves.toBe(ExitCode.SUCCESS);
     if (stdinTty) {
       Object.defineProperty(process.stdin, 'isTTY', stdinTty);
     }
@@ -1098,9 +1116,17 @@ describe('run + commands', () => {
     await expect(
       run(['node', 'ghst', 'page', 'update', fixtureIds.pageId, '--title', 'Updated Page']),
     ).resolves.toBe(ExitCode.SUCCESS);
-    await expect(run(['node', 'ghst', 'page', 'delete', fixtureIds.pageId, '--yes'])).resolves.toBe(
-      ExitCode.SUCCESS,
-    );
+    await expect(
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
+        'page',
+        'delete',
+        fixtureIds.pageId,
+        '--yes',
+      ]),
+    ).resolves.toBe(ExitCode.SUCCESS);
     await expect(run(['node', 'ghst', 'page', 'copy', fixtureIds.pageId])).resolves.toBe(
       ExitCode.SUCCESS,
     );
@@ -1108,6 +1134,7 @@ describe('run + commands', () => {
       run([
         'node',
         'ghst',
+        '--enable-destructive-actions',
         'page',
         'bulk',
         '--filter',
@@ -1122,6 +1149,7 @@ describe('run + commands', () => {
       run([
         'node',
         'ghst',
+        '--enable-destructive-actions',
         'page',
         'bulk',
         '--filter',
@@ -1153,13 +1181,22 @@ describe('run + commands', () => {
     await expect(
       run(['node', 'ghst', 'tag', 'update', fixtureIds.tagId, '--name', 'Updated Tag']),
     ).resolves.toBe(ExitCode.SUCCESS);
-    await expect(run(['node', 'ghst', 'tag', 'delete', fixtureIds.tagId, '--yes'])).resolves.toBe(
-      ExitCode.SUCCESS,
-    );
     await expect(
       run([
         'node',
         'ghst',
+        '--enable-destructive-actions',
+        'tag',
+        'delete',
+        fixtureIds.tagId,
+        '--yes',
+      ]),
+    ).resolves.toBe(ExitCode.SUCCESS);
+    await expect(
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
         'tag',
         'bulk',
         '--filter',
@@ -1174,6 +1211,7 @@ describe('run + commands', () => {
       run([
         'node',
         'ghst',
+        '--enable-destructive-actions',
         'tag',
         'bulk',
         '--filter',
@@ -1229,13 +1267,32 @@ describe('run + commands', () => {
       run(['node', 'ghst', 'member', 'bulk', '--action', 'unsubscribe', '--all']),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
-      run(['node', 'ghst', 'member', 'bulk', '--action', 'delete', '--all', '--yes']),
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
+        'member',
+        'bulk',
+        '--action',
+        'delete',
+        '--all',
+        '--yes',
+      ]),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
       run(['node', 'ghst', 'member', 'bulk', '--update', '--all', '--labels', 'VIP,Premium']),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
-      run(['node', 'ghst', 'member', 'bulk', '--delete', '--all', '--yes']),
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
+        'member',
+        'bulk',
+        '--delete',
+        '--all',
+        '--yes',
+      ]),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
       run(['node', 'ghst', 'member', 'import', './members.csv', '--labels', 'Imported']),
@@ -1244,7 +1301,15 @@ describe('run + commands', () => {
       run(['node', 'ghst', 'member', 'export', '--output', './members-export.csv']),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
-      run(['node', 'ghst', 'member', 'delete', fixtureIds.memberId, '--yes']),
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
+        'member',
+        'delete',
+        fixtureIds.memberId,
+        '--yes',
+      ]),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(fs.readFile(path.join(workDir, 'members-export.csv'), 'utf8')).resolves.toContain(
       'email',
@@ -1359,12 +1424,21 @@ describe('run + commands', () => {
       run(['node', 'ghst', 'label', 'update', fixtureIds.labelId, '--name', 'VIP Updated']),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
-      run(['node', 'ghst', 'label', 'delete', fixtureIds.labelId, '--yes']),
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
+        'label',
+        'delete',
+        fixtureIds.labelId,
+        '--yes',
+      ]),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
       run([
         'node',
         'ghst',
+        '--enable-destructive-actions',
         'label',
         'bulk',
         '--filter',
@@ -1379,6 +1453,7 @@ describe('run + commands', () => {
       run([
         'node',
         'ghst',
+        '--enable-destructive-actions',
         'label',
         'bulk',
         '--filter',
@@ -1537,7 +1612,16 @@ describe('run + commands', () => {
     );
 
     await expect(
-      run(['node', 'ghst', 'comment', 'delete', fixtureIds.commentId, '--yes', '--json']),
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
+        'comment',
+        'delete',
+        fixtureIds.commentId,
+        '--yes',
+        '--json',
+      ]),
     ).resolves.toBe(ExitCode.SUCCESS);
     expect(lastLogJson<{ comments: Array<{ status: string }> }>().comments[0]?.status).toBe(
       'deleted',
@@ -1630,7 +1714,15 @@ describe('run + commands', () => {
       ]),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
-      run(['node', 'ghst', 'webhook', 'delete', fixtureIds.webhookId, '--yes']),
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
+        'webhook',
+        'delete',
+        fixtureIds.webhookId,
+        '--yes',
+      ]),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
       run([
@@ -1775,7 +1867,17 @@ describe('run + commands', () => {
       run(['node', 'ghst', 'api', '/settings/', '--query', 'limit=1', 'status=published']),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
-      run(['node', 'ghst', 'api', '/posts/', '--method', 'POST', '--input', './payload.json']),
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
+        'api',
+        '/posts/',
+        '--method',
+        'POST',
+        '--input',
+        './payload.json',
+      ]),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
       run(['node', 'ghst', 'api', '/posts/', '--content-api', '--method', 'GET']),
@@ -1784,6 +1886,7 @@ describe('run + commands', () => {
       run([
         'node',
         'ghst',
+        '--enable-destructive-actions',
         'api',
         '/posts/',
         '--method',
@@ -1801,7 +1904,17 @@ describe('run + commands', () => {
       ExitCode.SUCCESS,
     );
     await expect(
-      run(['node', 'ghst', 'api', '/posts/', '--method', 'POST', '--field', 'status=draft']),
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
+        'api',
+        '/posts/',
+        '--method',
+        'POST',
+        '--field',
+        'status=draft',
+      ]),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
       run(['node', 'ghst', 'api', '/posts/', '--body', '{}', '--input', './payload.json']),
@@ -1992,6 +2105,25 @@ describe('run + commands', () => {
       run(['node', 'ghst', 'post', 'bulk', '--filter', 'status:draft', '--action', 'delete']),
     ).resolves.toBe(ExitCode.VALIDATION_ERROR);
     await expect(
+      run([
+        'node',
+        'ghst',
+        'post',
+        'bulk',
+        '--filter',
+        'status:draft',
+        '--action',
+        'delete',
+        '--yes',
+      ]),
+    ).resolves.toBe(ExitCode.USAGE_ERROR);
+    await expect(run(['node', 'ghst', 'post', 'delete', fixtureIds.postId, '--yes'])).resolves.toBe(
+      ExitCode.USAGE_ERROR,
+    );
+    await expect(
+      run(['node', 'ghst', 'api', '/posts/', '--method', 'POST', '--body', '{}']),
+    ).resolves.toBe(ExitCode.USAGE_ERROR);
+    await expect(
       run(['node', 'ghst', 'page', 'bulk', '--filter', 'status:draft', '--action', 'update']),
     ).resolves.toBe(ExitCode.VALIDATION_ERROR);
     await expect(
@@ -2026,9 +2158,16 @@ describe('run + commands', () => {
 
     const stdinTty = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
-    await expect(run(['node', 'ghst', 'member', 'delete', fixtureIds.memberId])).resolves.toBe(
-      ExitCode.USAGE_ERROR,
-    );
+    await expect(
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
+        'member',
+        'delete',
+        fixtureIds.memberId,
+      ]),
+    ).resolves.toBe(ExitCode.USAGE_ERROR);
     if (stdinTty) {
       Object.defineProperty(process.stdin, 'isTTY', stdinTty);
     }
@@ -2122,15 +2261,29 @@ describe('run + commands', () => {
     const stdinTty = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
     const stdoutTty = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
-    await expect(run(['node', 'ghst', 'webhook', 'delete', fixtureIds.webhookId])).resolves.toBe(
-      ExitCode.USAGE_ERROR,
-    );
+    await expect(
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
+        'webhook',
+        'delete',
+        fixtureIds.webhookId,
+      ]),
+    ).resolves.toBe(ExitCode.USAGE_ERROR);
     Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
     Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
     setPromptHandlerForTests(async () => 'no');
-    await expect(run(['node', 'ghst', 'webhook', 'delete', fixtureIds.webhookId])).resolves.toBe(
-      ExitCode.OPERATION_CANCELLED,
-    );
+    await expect(
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
+        'webhook',
+        'delete',
+        fixtureIds.webhookId,
+      ]),
+    ).resolves.toBe(ExitCode.OPERATION_CANCELLED);
     if (stdinTty) {
       Object.defineProperty(process.stdin, 'isTTY', stdinTty);
     }
@@ -2621,6 +2774,7 @@ describe('run + commands', () => {
         'https://myblog.ghost.io',
         '--staff-token',
         KEY,
+        '--enable-destructive-actions',
         'socialweb',
         'delete',
         'https://myblog.ghost.io/.ghost/activitypub/note/1',
@@ -2655,6 +2809,7 @@ describe('run + commands', () => {
       ['socialweb', 'repost', 'https://remote.example/posts/1', '--json'],
       ['socialweb', 'derepost', 'https://remote.example/posts/1', '--json'],
       [
+        '--enable-destructive-actions',
         'socialweb',
         'delete',
         'https://myblog.ghost.io/.ghost/activitypub/note/1',
@@ -2894,6 +3049,7 @@ describe('run + commands', () => {
       ['socialweb', 'unlike', 'https://remote.example/posts/1', '--json'],
       ['socialweb', 'derepost', 'https://remote.example/posts/1', '--json'],
       [
+        '--enable-destructive-actions',
         'socialweb',
         'delete',
         'https://myblog.ghost.io/.ghost/activitypub/note/1',

--- a/tests/comment-command-contracts.test.ts
+++ b/tests/comment-command-contracts.test.ts
@@ -185,7 +185,16 @@ describe('comment command contracts', () => {
       ExitCode.SUCCESS,
     );
     await expect(
-      run(['node', 'ghst', 'comment', 'delete', 'comment-1', '--yes', '--json']),
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
+        'comment',
+        'delete',
+        'comment-1',
+        '--yes',
+        '--json',
+      ]),
     ).resolves.toBe(ExitCode.SUCCESS);
 
     expect(commentMocks.setCommentStatus).toHaveBeenNthCalledWith(
@@ -210,16 +219,16 @@ describe('comment command contracts', () => {
     const stdinTty = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
     const stdoutTty = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
-    await expect(run(['node', 'ghst', 'comment', 'delete', 'comment-1'])).resolves.toBe(
-      ExitCode.USAGE_ERROR,
-    );
+    await expect(
+      run(['node', 'ghst', '--enable-destructive-actions', 'comment', 'delete', 'comment-1']),
+    ).resolves.toBe(ExitCode.USAGE_ERROR);
     Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
     Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
 
     setPromptHandlerForTests(async () => 'no');
-    await expect(run(['node', 'ghst', 'comment', 'delete', 'comment-1'])).resolves.toBe(
-      ExitCode.OPERATION_CANCELLED,
-    );
+    await expect(
+      run(['node', 'ghst', '--enable-destructive-actions', 'comment', 'delete', 'comment-1']),
+    ).resolves.toBe(ExitCode.OPERATION_CANCELLED);
 
     if (stdinTty) {
       Object.defineProperty(process.stdin, 'isTTY', stdinTty);
@@ -241,9 +250,9 @@ describe('comment command contracts', () => {
     );
 
     setPromptHandlerForTests(async () => 'yes');
-    await expect(run(['node', 'ghst', 'comment', 'delete', 'comment-1'])).resolves.toBe(
-      ExitCode.SUCCESS,
-    );
+    await expect(
+      run(['node', 'ghst', '--enable-destructive-actions', 'comment', 'delete', 'comment-1']),
+    ).resolves.toBe(ExitCode.SUCCESS);
 
     await expect(run(['node', 'ghst', 'comment', 'show', ''])).resolves.toBe(
       ExitCode.VALIDATION_ERROR,

--- a/tests/mcp-core-tools.test.ts
+++ b/tests/mcp-core-tools.test.ts
@@ -112,7 +112,11 @@ describe('mcp core tool registration', () => {
 
   test('registers all tool groups and executes handlers', async () => {
     const { server, tools } = createRegistry();
-    registerCoreTools(server as never, {}, new Set(MCP_TOOL_GROUPS));
+    registerCoreTools(
+      server as never,
+      { enableDestructiveActions: true },
+      new Set(MCP_TOOL_GROUPS),
+    );
 
     expect([...tools.keys()]).toEqual(
       expect.arrayContaining([
@@ -339,6 +343,7 @@ describe('mcp core tool registration', () => {
     });
     await run('ghost_socialweb_delete', {
       id: 'https://myblog.ghost.io/.ghost/activitypub/note/1',
+      confirm: true,
     });
 
     const socialNoteResponse = await run('ghost_socialweb_note', {
@@ -468,6 +473,28 @@ describe('mcp core tool registration', () => {
     await expect(tool?.handler({ path: '/%2E%2E%2Fmembers/' }) as Promise<unknown>).rejects.toThrow(
       'encoded path separators',
     );
+  });
+
+  test('rejects destructive mcp tools unless destructive actions are enabled', async () => {
+    const { server, tools } = createRegistry();
+    registerCoreTools(server as never, {}, new Set(MCP_TOOL_GROUPS));
+
+    const deleteTool = tools.get('ghost_post_delete');
+    const apiTool = tools.get('ghost_api_request');
+    expect(deleteTool).toBeDefined();
+    expect(apiTool).toBeDefined();
+
+    await expect(
+      deleteTool?.handler({ id: fixtureIds.postId, confirm: true }) as Promise<unknown>,
+    ).rejects.toThrow('Destructive actions are disabled');
+
+    await expect(
+      apiTool?.handler({
+        path: '/posts/',
+        method: 'POST',
+        body: { posts: [{ title: 'Blocked' }] },
+      }) as Promise<unknown> | undefined,
+    ).rejects.toThrow('Destructive actions are disabled');
   });
 
   test('rejects socialweb all_pages combined with next to preserve cli parity', async () => {


### PR DESCRIPTION
## Summary

- add a global `--enable-destructive-actions` opt-in for destructive CLI operations
- keep `--yes` scoped to confirmation skipping while guarding delete-style command paths before prompts or network calls
- require the same opt-in for raw API non-read requests and MCP destructive tools
- update docs and command contract coverage for the new behavior

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

`pnpm lint` reports the existing Biome schema/optional-chain warnings only.