### PR TITLE
Group MCP tools by category metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,8 @@ pnpm build
 - `users`
 - `api`
 - `search`
-- `stats`
 - `socialweb`
+- `stats`
 
 ## Behavior Notes
 
@@ -129,6 +129,7 @@ pnpm build
 - MCP now exposes first-class stats tools via the `stats` tool group rather than requiring raw `ghost_api_request` calls.
 - MCP now exposes first-class comment moderation tools via the `comments` tool group, including list/get/thread/replies/likes/reports/hide/show/delete.
 - MCP now exposes first-class social web tools via the `socialweb` tool group, covering status/profile/feed/interaction/moderation/upload flows.
+- MCP `tools/list` exposes `ghst/toolGroup` and `ghst/toolGroupTitle` metadata for clients that can render grouped tools.
 - `api [endpointPath]` only accepts resource-relative paths or canonical Ghost API paths within the selected API root.
 - `mcp http` requires `--unsafe-public-bind` for non-loopback hosts and `--cors-origin` accepts one exact origin only.
 - MCP includes dedicated tools such as `ghost_post_schedule`, `ghost_image_upload`, `ghost_member_import`, `ghost_newsletter_list`, `ghost_tier_list`, `ghost_offer_list`, `ghost_theme_upload`, and `ghost_webhook_create`.

--- a/README.md
+++ b/README.md
@@ -333,6 +333,8 @@ Notes:
 
 - `ghst mcp http` binds to loopback by default. Binding to a non-loopback host requires `--unsafe-public-bind`.
 - `--cors-origin` accepts a single exact origin only, for example `https://app.example.com`.
+- `--tools` accepts `all` or comma-separated group names such as `posts,stats`.
+- Exposed MCP tools include `ghst/toolGroup` and `ghst/toolGroupTitle` metadata for clients that render grouped tools.
 
 Supported tool groups:
 

--- a/src/mcp/tools/core.ts
+++ b/src/mcp/tools/core.ts
@@ -1,4 +1,6 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer, ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { normalizeGhostApiPath } from '../../lib/api-path.js';
 import { GhostClient } from '../../lib/client.js';
@@ -120,6 +122,51 @@ export const MCP_TOOL_GROUPS: readonly McpToolGroup[] = [
   'socialweb',
   'stats',
 ] as const;
+
+export const MCP_TOOL_GROUP_METADATA: Record<McpToolGroup, { title: string }> = {
+  posts: { title: 'Posts' },
+  pages: { title: 'Pages' },
+  tags: { title: 'Tags' },
+  members: { title: 'Members' },
+  comments: { title: 'Comments' },
+  site: { title: 'Site' },
+  settings: { title: 'Settings' },
+  users: { title: 'Users' },
+  api: { title: 'API' },
+  search: { title: 'Search' },
+  socialweb: { title: 'Social web' },
+  stats: { title: 'Stats' },
+} as const;
+
+type GroupedToolConfig<InputSchema extends AnySchema | undefined = undefined> = {
+  title?: string;
+  description?: string;
+  inputSchema?: InputSchema;
+  outputSchema?: AnySchema;
+  annotations?: ToolAnnotations;
+  _meta?: Record<string, unknown>;
+};
+
+function registerGroupedTool<InputSchema extends AnySchema | undefined = undefined>(
+  server: McpServer,
+  group: McpToolGroup,
+  name: string,
+  config: GroupedToolConfig<InputSchema>,
+  handler: ToolCallback<InputSchema>,
+): void {
+  const metadata = MCP_TOOL_GROUP_METADATA[group];
+  const groupedConfig = {
+    ...config,
+    _meta: {
+      ...config._meta,
+      'ghst/toolGroup': group,
+      'ghst/toolGroupTitle': metadata.title,
+    },
+  };
+
+  // The SDK's registerTool generics do not preserve this enriched config shape cleanly.
+  server.registerTool(name, groupedConfig as GroupedToolConfig<InputSchema>, handler);
+}
 
 const statsRangeArgs = {
   range: z.enum(['7d', '30d', '90d', '365d', 'all']).optional(),
@@ -393,7 +440,9 @@ export function registerCoreTools(
   enabledGroups: Set<McpToolGroup>,
 ): void {
   if (enabledGroups.has('posts')) {
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'posts',
       'ghost_post_list',
       {
         description: 'List Ghost posts.',
@@ -411,7 +460,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'posts',
       'ghost_post_get',
       {
         description: 'Get a Ghost post by id or slug.',
@@ -432,7 +483,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'posts',
       'ghost_post_create',
       {
         description: 'Create a Ghost post.',
@@ -462,7 +515,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'posts',
       'ghost_post_update',
       {
         description: 'Update a Ghost post by id or slug.',
@@ -495,7 +550,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'posts',
       'ghost_post_delete',
       {
         description: 'Delete a Ghost post.',
@@ -510,7 +567,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'posts',
       'ghost_post_publish',
       {
         description: 'Publish a Ghost post.',
@@ -524,7 +583,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'posts',
       'ghost_post_schedule',
       {
         description: 'Schedule a Ghost post, with optional email delivery settings.',
@@ -546,7 +607,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'posts',
       'ghost_image_upload',
       {
         description: 'Upload an image and return the uploaded image payload.',
@@ -568,7 +631,9 @@ export function registerCoreTools(
   }
 
   if (enabledGroups.has('pages')) {
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'pages',
       'ghost_page_list',
       {
         description: 'List Ghost pages.',
@@ -586,7 +651,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'pages',
       'ghost_page_get',
       {
         description: 'Get a Ghost page by id or slug.',
@@ -607,7 +674,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'pages',
       'ghost_page_create',
       {
         description: 'Create a Ghost page.',
@@ -635,7 +704,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'pages',
       'ghost_page_update',
       {
         description: 'Update a Ghost page by id or slug.',
@@ -666,7 +737,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'pages',
       'ghost_page_delete',
       {
         description: 'Delete a Ghost page.',
@@ -683,7 +756,9 @@ export function registerCoreTools(
   }
 
   if (enabledGroups.has('tags')) {
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'tags',
       'ghost_tag_list',
       {
         description: 'List Ghost tags.',
@@ -696,7 +771,9 @@ export function registerCoreTools(
       async (args) => toolResult(await listTags(global, { ...args }, false)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'tags',
       'ghost_tag_get',
       {
         description: 'Get a Ghost tag by id or slug.',
@@ -713,7 +790,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'tags',
       'ghost_tag_create',
       {
         description: 'Create a Ghost tag.',
@@ -726,7 +805,9 @@ export function registerCoreTools(
       async (args) => toolResult(await createTag(global, args)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'tags',
       'ghost_tag_update',
       {
         description: 'Update a Ghost tag.',
@@ -750,7 +831,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'tags',
       'ghost_tag_delete',
       {
         description: 'Delete a Ghost tag.',
@@ -764,7 +847,9 @@ export function registerCoreTools(
   }
 
   if (enabledGroups.has('members')) {
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'members',
       'ghost_member_list',
       {
         description: 'List Ghost members.',
@@ -778,7 +863,9 @@ export function registerCoreTools(
       async (args) => toolResult(await listMembers(global, { ...args }, false)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'members',
       'ghost_member_get',
       {
         description: 'Get Ghost member by id or email.',
@@ -796,7 +883,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'members',
       'ghost_member_create',
       {
         description: 'Create Ghost member.',
@@ -818,7 +907,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'members',
       'ghost_member_update',
       {
         description: 'Update Ghost member.',
@@ -842,7 +933,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'members',
       'ghost_member_delete',
       {
         description: 'Delete Ghost member.',
@@ -854,7 +947,9 @@ export function registerCoreTools(
       async (args) => toolResult(await deleteMember(global, args.id)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'members',
       'ghost_member_import',
       {
         description: 'Import members from a CSV file path.',
@@ -872,7 +967,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'members',
       'ghost_newsletter_list',
       {
         description: 'List Ghost newsletters.',
@@ -885,7 +982,9 @@ export function registerCoreTools(
       async (args) => toolResult(await listNewsletters(global, { ...args }, false)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'members',
       'ghost_tier_list',
       {
         description: 'List Ghost tiers.',
@@ -898,7 +997,9 @@ export function registerCoreTools(
       async (args) => toolResult(await listTiers(global, { ...args }, false)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'members',
       'ghost_offer_list',
       {
         description: 'List Ghost offers.',
@@ -913,7 +1014,9 @@ export function registerCoreTools(
   }
 
   if (enabledGroups.has('comments')) {
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'comments',
       'ghost_comment_list',
       {
         description: 'List Ghost comments from the Admin moderation view.',
@@ -939,7 +1042,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'comments',
       'ghost_comment_get',
       {
         description: 'Get a Ghost comment with Admin moderation fields.',
@@ -950,7 +1055,9 @@ export function registerCoreTools(
       async (args) => toolResult(await getComment(global, args.id)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'comments',
       'ghost_comment_thread',
       {
         description: 'Get a Ghost comment thread using the Admin moderation thread view.',
@@ -961,7 +1068,9 @@ export function registerCoreTools(
       async (args) => toolResult(await getCommentThread(global, args.id)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'comments',
       'ghost_comment_replies',
       {
         description: 'List replies for a Ghost comment using the raw replies endpoint.',
@@ -985,7 +1094,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'comments',
       'ghost_comment_likes',
       {
         description: 'List likes for a Ghost comment.',
@@ -1009,7 +1120,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'comments',
       'ghost_comment_reports',
       {
         description: 'List reports for a Ghost comment.',
@@ -1033,7 +1146,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'comments',
       'ghost_comment_hide',
       {
         description: 'Hide a Ghost comment.',
@@ -1044,7 +1159,9 @@ export function registerCoreTools(
       async (args) => toolResult(await setCommentStatus(global, args.id, 'hidden')),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'comments',
       'ghost_comment_show',
       {
         description: 'Show a previously hidden Ghost comment.',
@@ -1055,7 +1172,9 @@ export function registerCoreTools(
       async (args) => toolResult(await setCommentStatus(global, args.id, 'published')),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'comments',
       'ghost_comment_delete',
       {
         description: 'Soft-delete a Ghost comment.',
@@ -1069,7 +1188,9 @@ export function registerCoreTools(
   }
 
   if (enabledGroups.has('site')) {
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'site',
       'ghost_site_info',
       {
         description: 'Get Ghost site metadata.',
@@ -1077,7 +1198,9 @@ export function registerCoreTools(
       async () => toolResult(await getSiteInfo(global)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'site',
       'ghost_theme_upload',
       {
         description: 'Upload a Ghost theme zip path and optionally activate it.',
@@ -1103,7 +1226,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'site',
       'ghost_webhook_create',
       {
         description: 'Create a Ghost webhook.',
@@ -1129,7 +1254,9 @@ export function registerCoreTools(
   }
 
   if (enabledGroups.has('settings')) {
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'settings',
       'ghost_setting_list',
       {
         description: 'List Ghost settings.',
@@ -1137,7 +1264,9 @@ export function registerCoreTools(
       async () => toolResult(await listSettings(global)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'settings',
       'ghost_setting_get',
       {
         description: 'Get a Ghost setting by key.',
@@ -1148,7 +1277,9 @@ export function registerCoreTools(
       async (args) => toolResult(await getSetting(global, args.key)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'settings',
       'ghost_setting_set',
       {
         description: 'Set a Ghost setting by key.',
@@ -1162,7 +1293,9 @@ export function registerCoreTools(
   }
 
   if (enabledGroups.has('users')) {
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'users',
       'ghost_user_list',
       {
         description: 'List Ghost staff users.',
@@ -1176,7 +1309,9 @@ export function registerCoreTools(
   }
 
   if (enabledGroups.has('api')) {
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'api',
       'ghost_api_request',
       {
         description: 'Run a raw Ghost API request.',
@@ -1204,7 +1339,9 @@ export function registerCoreTools(
   }
 
   if (enabledGroups.has('search')) {
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'search',
       'ghost_search',
       {
         description: 'Search posts, pages, tags and members.',
@@ -1218,7 +1355,9 @@ export function registerCoreTools(
   }
 
   if (enabledGroups.has('socialweb')) {
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_status',
       {
         description: 'Show Ghost social web settings and connectivity status.',
@@ -1226,7 +1365,9 @@ export function registerCoreTools(
       async () => toolResult(await getSocialWebStatus(global)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_enable',
       {
         description: 'Enable Ghost social web and return the resulting status.',
@@ -1234,7 +1375,9 @@ export function registerCoreTools(
       async () => toolResult(await enableSocialWeb(global)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_disable',
       {
         description: 'Disable Ghost social web and return the resulting status.',
@@ -1242,7 +1385,9 @@ export function registerCoreTools(
       async () => toolResult(await disableSocialWeb(global)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_profile',
       {
         description: 'Get a social web profile by federated handle or me.',
@@ -1253,7 +1398,9 @@ export function registerCoreTools(
       async (args) => toolResult(await getSocialWebProfile(global, args.handle ?? 'me')),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_profile_update',
       {
         description: 'Update the current social web profile.',
@@ -1271,7 +1418,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_search',
       {
         description: 'Search social web accounts.',
@@ -1282,7 +1431,9 @@ export function registerCoreTools(
       async (args) => toolResult(await searchSocialWeb(global, args.query)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_notes',
       {
         description: 'List the social web note feed.',
@@ -1294,7 +1445,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_reader',
       {
         description: 'List the social web reader feed.',
@@ -1306,7 +1459,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_notifications',
       {
         description: 'List social web notifications.',
@@ -1318,7 +1473,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_notifications_count',
       {
         description: 'Get the unread social web notification count.',
@@ -1326,7 +1483,9 @@ export function registerCoreTools(
       async () => toolResult(await getNotificationsCount(global)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_posts',
       {
         description: 'List posts for a social web account.',
@@ -1345,7 +1504,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_likes',
       {
         description: 'List posts liked by the current social web account.',
@@ -1357,7 +1518,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_followers',
       {
         description: 'List followers for a social web account.',
@@ -1371,7 +1534,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_following',
       {
         description: 'List followed accounts for a social web account.',
@@ -1385,7 +1550,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_post',
       {
         description: 'Get a social web post by ActivityPub id.',
@@ -1396,7 +1563,9 @@ export function registerCoreTools(
       async (args) => toolResult(await getSocialWebPost(global, args.id)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_thread',
       {
         description: 'Get a social web thread by ActivityPub id.',
@@ -1407,7 +1576,9 @@ export function registerCoreTools(
       async (args) => toolResult(await getSocialWebThread(global, args.id)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_follow',
       {
         description: 'Follow a federated social web account.',
@@ -1418,7 +1589,9 @@ export function registerCoreTools(
       async (args) => toolResult(await followAccount(global, args.handle)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_unfollow',
       {
         description: 'Unfollow a federated social web account.',
@@ -1429,7 +1602,9 @@ export function registerCoreTools(
       async (args) => toolResult(await unfollowAccount(global, args.handle)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_like',
       {
         description: 'Like a social web post.',
@@ -1440,7 +1615,9 @@ export function registerCoreTools(
       async (args) => toolResult(await likePost(global, args.id)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_unlike',
       {
         description: 'Unlike a social web post.',
@@ -1451,7 +1628,9 @@ export function registerCoreTools(
       async (args) => toolResult(await unlikePost(global, args.id)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_repost',
       {
         description: 'Repost a social web post.',
@@ -1462,7 +1641,9 @@ export function registerCoreTools(
       async (args) => toolResult(await repostPost(global, args.id)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_derepost',
       {
         description: 'Undo a repost on a social web post.',
@@ -1473,7 +1654,9 @@ export function registerCoreTools(
       async (args) => toolResult(await derepostPost(global, args.id)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_delete',
       {
         description: 'Delete a social web post authored by the current account.',
@@ -1484,7 +1667,9 @@ export function registerCoreTools(
       async (args) => toolResult(await deleteSocialWebPost(global, args.id)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_note',
       {
         description: 'Create a new social web note.',
@@ -1501,7 +1686,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_reply',
       {
         description: 'Reply to a social web post.',
@@ -1520,7 +1707,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_blocked_accounts',
       {
         description: 'List blocked social web accounts.',
@@ -1534,7 +1723,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_blocked_domains',
       {
         description: 'List blocked social web domains.',
@@ -1546,7 +1737,9 @@ export function registerCoreTools(
       },
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_block',
       {
         description: 'Block a social web account by ActivityPub id.',
@@ -1557,7 +1750,9 @@ export function registerCoreTools(
       async (args) => toolResult(await blockAccount(global, args.id)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_unblock',
       {
         description: 'Unblock a social web account by ActivityPub id.',
@@ -1568,7 +1763,9 @@ export function registerCoreTools(
       async (args) => toolResult(await unblockAccount(global, args.id)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_block_domain',
       {
         description: 'Block a social web domain.',
@@ -1579,7 +1776,9 @@ export function registerCoreTools(
       async (args) => toolResult(await blockDomain(global, args.url)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_unblock_domain',
       {
         description: 'Unblock a social web domain.',
@@ -1590,7 +1789,9 @@ export function registerCoreTools(
       async (args) => toolResult(await unblockDomain(global, args.url)),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'socialweb',
       'ghost_socialweb_upload',
       {
         description: 'Upload an image for social web notes and replies.',
@@ -1603,7 +1804,9 @@ export function registerCoreTools(
   }
 
   if (enabledGroups.has('stats')) {
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'stats',
       'ghost_stats_overview',
       {
         description: 'Get the Ghost analytics overview report.',
@@ -1614,7 +1817,9 @@ export function registerCoreTools(
       async (args) => toolResult(await getStatsOverview(global, mapStatsRangeArgs(args))),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'stats',
       'ghost_stats_web',
       {
         description: 'Get the Ghost web analytics report.',
@@ -1625,7 +1830,9 @@ export function registerCoreTools(
       async (args) => toolResult(await getStatsWeb(global, mapStatsWebArgs(args))),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'stats',
       'ghost_stats_web_table',
       {
         description: 'Get a focused Ghost web analytics table view.',
@@ -1643,7 +1850,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'stats',
       'ghost_stats_growth',
       {
         description: 'Get Ghost member and revenue growth analytics.',
@@ -1658,7 +1867,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'stats',
       'ghost_stats_posts',
       {
         description: 'Get top Ghost posts by views.',
@@ -1673,7 +1884,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'stats',
       'ghost_stats_email',
       {
         description: 'Get Ghost email analytics grouped by newsletter.',
@@ -1693,7 +1906,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'stats',
       'ghost_stats_email_clicks',
       {
         description:
@@ -1716,7 +1931,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'stats',
       'ghost_stats_email_subscribers',
       {
         description: 'Get Ghost newsletter subscriber analytics.',
@@ -1734,7 +1951,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'stats',
       'ghost_stats_post',
       {
         description: 'Get Ghost analytics for a single post.',
@@ -1747,7 +1966,9 @@ export function registerCoreTools(
         toolResult(await getStatsPost(global, { ...mapStatsRangeArgs(args), id: args.id })),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'stats',
       'ghost_stats_post_web',
       {
         description: 'Get Ghost web analytics for a single post.',
@@ -1760,7 +1981,9 @@ export function registerCoreTools(
         toolResult(await getStatsPostWeb(global, { ...mapStatsWebArgs(args), id: args.id })),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'stats',
       'ghost_stats_post_growth',
       {
         description: 'Get Ghost growth analytics for a single post.',
@@ -1773,7 +1996,9 @@ export function registerCoreTools(
         toolResult(await getStatsPostGrowth(global, { ...mapStatsRangeArgs(args), id: args.id })),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'stats',
       'ghost_stats_post_newsletter',
       {
         description: 'Get Ghost email performance analytics for a single post.',
@@ -1788,7 +2013,9 @@ export function registerCoreTools(
         ),
     );
 
-    server.registerTool(
+    registerGroupedTool(
+      server,
+      'stats',
       'ghost_stats_post_referrers',
       {
         description: 'Get Ghost referrer analytics for a single post.',

--- a/tests/mcp-core-tools.test.ts
+++ b/tests/mcp-core-tools.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import {
+  MCP_TOOL_GROUP_METADATA,
   MCP_TOOL_GROUPS,
   type McpToolGroup,
   parseToolGroups,
@@ -130,6 +131,30 @@ describe('mcp core tool registration', () => {
         'ghost_stats_overview',
       ]),
     );
+
+    expect(tools.get('ghost_post_list')?.meta._meta).toMatchObject({
+      'ghst/toolGroup': 'posts',
+      'ghst/toolGroupTitle': 'Posts',
+    });
+    expect(tools.get('ghost_site_info')?.meta._meta).toMatchObject({
+      'ghst/toolGroup': 'site',
+      'ghst/toolGroupTitle': 'Site',
+    });
+    expect(tools.get('ghost_stats_overview')?.meta._meta).toMatchObject({
+      'ghst/toolGroup': 'stats',
+      'ghst/toolGroupTitle': 'Stats',
+    });
+
+    for (const [name, tool] of tools) {
+      const metadata = tool.meta._meta as Record<string, unknown> | undefined;
+      const group = metadata?.['ghst/toolGroup'] as McpToolGroup | undefined;
+
+      expect(metadata, `${name} should expose MCP group metadata`).toBeDefined();
+      expect(MCP_TOOL_GROUPS, `${name} should use a known MCP tool group`).toContain(group);
+      expect(metadata?.['ghst/toolGroupTitle']).toBe(
+        group ? MCP_TOOL_GROUP_METADATA[group].title : undefined,
+      );
+    }
 
     const run = async (
       name: string,
@@ -548,6 +573,12 @@ describe('mcp core tool registration', () => {
       'ghost_theme_upload',
       'ghost_webhook_create',
     ]);
+    for (const tool of tools.values()) {
+      expect(tool.meta._meta).toMatchObject({
+        'ghst/toolGroup': 'site',
+        'ghst/toolGroupTitle': 'Site',
+      });
+    }
   });
 
   test('can register only socialweb tools', () => {

--- a/tests/mcp-http-integration.test.ts
+++ b/tests/mcp-http-integration.test.ts
@@ -44,7 +44,46 @@ async function waitForServer(url: string, timeoutMs = 1000): Promise<void> {
   }
 }
 
+function parseMcpJsonResponse(body: string): {
+  result?: {
+    tools?: Array<{
+      name: string;
+      _meta?: Record<string, unknown>;
+    }>;
+  };
+} {
+  const trimmed = body.trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const dataLines = trimmed
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice('data:'.length).trimStart());
+
+    if (dataLines.length === 0) {
+      throw new Error('MCP event-stream response did not include a data line');
+    }
+
+    return JSON.parse(dataLines.join('\n'));
+  }
+}
+
 describe.sequential('mcp http integration', () => {
+  test('parses JSON and event-stream MCP responses', () => {
+    expect(parseMcpJsonResponse('{"result":{"tools":[]}}')).toEqual({
+      result: { tools: [] },
+    });
+    expect(parseMcpJsonResponse('data: {"result":{"tools":[]}}\n\n')).toEqual({
+      result: { tools: [] },
+    });
+    expect(
+      parseMcpJsonResponse('event: message\ndata: {"result":\ndata: {"tools":[]}}\n\n'),
+    ).toEqual({
+      result: { tools: [] },
+    });
+  });
+
   test('supports initialize plus follow-up requests with the real SDK transport', async () => {
     const port = await getFreePort();
     const runPromise = runMcpHttp(
@@ -128,7 +167,12 @@ describe.sequential('mcp http integration', () => {
       });
 
       expect(toolsListResponse.status).toBe(200);
-      expect(await toolsListResponse.text()).toContain('"tools":');
+      const toolsListBody = parseMcpJsonResponse(await toolsListResponse.text());
+      const siteTool = toolsListBody.result?.tools?.find((tool) => tool.name === 'ghost_site_info');
+      expect(siteTool?._meta).toMatchObject({
+        'ghst/toolGroup': 'site',
+        'ghst/toolGroupTitle': 'Site',
+      });
     } finally {
       process.emit('SIGINT');
       await runPromise;


### PR DESCRIPTION
## Summary

- expose stable `ghst/toolGroup` and `ghst/toolGroupTitle` metadata on every MCP tool
- route MCP tool registration through a grouped helper while preserving existing tool names and `--tools` group filtering
- document the grouped metadata and add registry plus HTTP transport coverage

## Validation

- `pnpm lint && pnpm typecheck && pnpm test && pnpm build && git diff --check`

Closes #70