### PR TITLE
fix: send newsletter email on publish; remove no-op create flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ pnpm build
 - `auth logout` requires `--enable-destructive-actions` when removing configured sites and confirmation when removing all configured sites; non-interactive all-site removal also requires `--yes`.
 - `auth link` requires `--enable-destructive-actions` and confirmation before replacing an existing project link; non-interactive use requires `--yes`, and relinking updates the discovered project config within the enclosing repo.
 - Interactive destructive confirmations emit `GHST_AGENT_NOTICE:` lines on stderr instructing cooperative agents to ask the user for approval before continuing.
-- `post publish|schedule` supports `--newsletter`, `--email-segment`, and `--email-only`.
+- `post publish|schedule|update` supports `--newsletter`, `--email-segment`, and `--email-only`.
 - `post delete` supports either `<id>` or `--filter` (requires `--enable-destructive-actions`; non-interactive delete also requires `--yes`).
 - `post bulk` supports `--action` plus compatibility aliases `--update`/`--delete` and update fields including `--add-tag` and `--authors`.
 - `member list --status` composes with `--filter`.

--- a/README.md
+++ b/README.md
@@ -165,9 +165,11 @@ Interactive destructive confirmations also emit `GHST_AGENT_NOTICE:` lines on st
 Create and publish:
 
 ```bash
-ghst post create --title "Launch" --markdown-file ./launch.md --newsletter weekly --email-segment all
-ghst post publish <post-id>
+ghst post create --title "Launch" --markdown-file ./launch.md
+ghst post publish <post-id> --newsletter weekly --email-segment all
 ```
+
+The email delivery flags (`--newsletter`, `--email-only`, `--email-segment`) belong on `post publish` (or `post schedule` / `post update`) — Ghost's email send pipeline fires on the publish transition, not on create.
 
 Bulk updates:
 

--- a/src/commands/post.ts
+++ b/src/commands/post.ts
@@ -7,6 +7,7 @@ import { ExitCode, GhstError } from '../lib/errors.js';
 import { printJson, printPostHuman, printPostListHuman } from '../lib/output.js';
 import { parseBooleanFlag, parseCsv, parseInteger } from '../lib/parse.js';
 import {
+  buildEmailParams,
   bulkPosts,
   copyPost,
   createPost,
@@ -240,9 +241,6 @@ export function registerPostCommands(program: Command): void {
     .option('--og-title <title>', 'Open Graph title')
     .option('--og-image <url>', 'Open Graph image URL')
     .option('--code-injection-head <value>', 'Code injection head HTML')
-    .option('--newsletter <slug>', 'Newsletter slug for published posts')
-    .option('--email-only', 'Publish as email-only')
-    .option('--email-segment <segment>', 'Email segment for publish email')
     .action(async (options, command) => {
       const global = getGlobalOptions(command);
       const parsed = PostCreateInputSchema.safeParse({
@@ -268,9 +266,6 @@ export function registerPostCommands(program: Command): void {
         ogTitle: options.ogTitle,
         ogImage: options.ogImage,
         codeInjectionHead: options.codeInjectionHead,
-        newsletter: options.newsletter,
-        emailOnly: parseBooleanFlag(options.emailOnly),
-        emailSegment: options.emailSegment,
       });
 
       if (!parsed.success) {
@@ -325,26 +320,7 @@ export function registerPostCommands(program: Command): void {
         },
       );
 
-      // Ghost requires email-related fields as URL query parameters, not
-      // body fields, to trigger the email-on-publish pathway. Same as
-      // publishPost / schedulePost in src/lib/posts.ts.
-      const emailParams: Record<string, string> = {};
-      if (parsed.data.newsletter) {
-        emailParams.newsletter = parsed.data.newsletter;
-      }
-      if (parsed.data.emailSegment) {
-        emailParams.email_segment = parsed.data.emailSegment;
-      }
-      if (parsed.data.emailOnly !== undefined) {
-        emailParams.email_only = String(parsed.data.emailOnly);
-      }
-
-      const payload = await createPost(
-        global,
-        createPayload,
-        source,
-        Object.keys(emailParams).length > 0 ? emailParams : undefined,
-      );
+      const payload = await createPost(global, createPayload, source);
 
       if (global.json) {
         printJson(payload, global.jq);
@@ -380,9 +356,9 @@ export function registerPostCommands(program: Command): void {
     .option('--og-title <title>', 'Open Graph title')
     .option('--og-image <url>', 'Open Graph image URL')
     .option('--code-injection-head <value>', 'Code injection head HTML')
-    .option('--newsletter <slug>', 'Newsletter slug')
-    .option('--email-only <value>', 'true|false')
-    .option('--email-segment <segment>', 'Email segment')
+    .option('--newsletter <slug>', 'Newsletter slug for email delivery')
+    .option('--email-only <value>', 'Send as email only (true|false)')
+    .option('--email-segment <segment>', 'Email segment for delivery')
     .action(async (id: string | undefined, options, command) => {
       const global = getGlobalOptions(command);
       const parsed = PostUpdateInputSchema.safeParse({
@@ -464,25 +440,16 @@ export function registerPostCommands(program: Command): void {
         },
       );
 
-      // Ghost requires email-related fields as URL query parameters, not
-      // body fields, to trigger the email-on-publish pathway.
-      const emailParams: Record<string, string> = {};
-      if (parsed.data.newsletter) {
-        emailParams.newsletter = parsed.data.newsletter;
-      }
-      if (parsed.data.emailSegment) {
-        emailParams.email_segment = parsed.data.emailSegment;
-      }
-      if (parsed.data.emailOnly !== undefined) {
-        emailParams.email_only = String(parsed.data.emailOnly);
-      }
-
       const payload = await updatePost(global, {
         id: parsed.data.id,
         slug: parsed.data.slug,
         patch,
         source,
-        params: Object.keys(emailParams).length > 0 ? emailParams : undefined,
+        params: buildEmailParams({
+          newsletter: parsed.data.newsletter,
+          email_only: parsed.data.emailOnly,
+          email_segment: parsed.data.emailSegment,
+        }),
       });
 
       if (global.json) {
@@ -570,9 +537,9 @@ export function registerPostCommands(program: Command): void {
   post
     .command('publish <id>')
     .description('Publish a post')
-    .option('--newsletter <slug>', 'Newsletter slug')
-    .option('--email-segment <segment>', 'Email segment')
-    .option('--email-only', 'Email only publish')
+    .option('--newsletter <slug>', 'Newsletter slug for email delivery')
+    .option('--email-segment <segment>', 'Email segment for delivery')
+    .option('--email-only', 'Send as email only')
     .action(async (id: string, options, command) => {
       const global = getGlobalOptions(command);
       const parsed = PostPublishInputSchema.safeParse({
@@ -605,8 +572,8 @@ export function registerPostCommands(program: Command): void {
     .description('Schedule a post')
     .requiredOption('--at <datetime>', 'ISO datetime for scheduled publish')
     .option('--newsletter <slug>', 'Newsletter slug for email delivery')
-    .option('--email-only', 'Email only publish')
-    .option('--email-segment <segment>', 'Email segment')
+    .option('--email-only', 'Send as email only')
+    .option('--email-segment <segment>', 'Email segment for delivery')
     .action(async (id: string, options, command) => {
       const global = getGlobalOptions(command);
       const parsed = PostScheduleInputSchema.safeParse({

--- a/src/commands/post.ts
+++ b/src/commands/post.ts
@@ -322,13 +322,29 @@ export function registerPostCommands(program: Command): void {
           og_title: parsed.data.ogTitle,
           og_image: parsed.data.ogImage,
           codeinjection_head: parsed.data.codeInjectionHead,
-          newsletter: parsed.data.newsletter,
-          email_only: parsed.data.emailOnly,
-          email_segment: parsed.data.emailSegment,
         },
       );
 
-      const payload = await createPost(global, createPayload, source);
+      // Ghost requires email-related fields as URL query parameters, not
+      // body fields, to trigger the email-on-publish pathway. Same as
+      // publishPost / schedulePost in src/lib/posts.ts.
+      const emailParams: Record<string, string> = {};
+      if (parsed.data.newsletter) {
+        emailParams.newsletter = parsed.data.newsletter;
+      }
+      if (parsed.data.emailSegment) {
+        emailParams.email_segment = parsed.data.emailSegment;
+      }
+      if (parsed.data.emailOnly !== undefined) {
+        emailParams.email_only = String(parsed.data.emailOnly);
+      }
+
+      const payload = await createPost(
+        global,
+        createPayload,
+        source,
+        Object.keys(emailParams).length > 0 ? emailParams : undefined,
+      );
 
       if (global.json) {
         printJson(payload, global.jq);
@@ -445,17 +461,28 @@ export function registerPostCommands(program: Command): void {
           og_title: parsed.data.ogTitle,
           og_image: parsed.data.ogImage,
           codeinjection_head: parsed.data.codeInjectionHead,
-          newsletter: parsed.data.newsletter,
-          email_only: parsed.data.emailOnly,
-          email_segment: parsed.data.emailSegment,
         },
       );
+
+      // Ghost requires email-related fields as URL query parameters, not
+      // body fields, to trigger the email-on-publish pathway.
+      const emailParams: Record<string, string> = {};
+      if (parsed.data.newsletter) {
+        emailParams.newsletter = parsed.data.newsletter;
+      }
+      if (parsed.data.emailSegment) {
+        emailParams.email_segment = parsed.data.emailSegment;
+      }
+      if (parsed.data.emailOnly !== undefined) {
+        emailParams.email_only = String(parsed.data.emailOnly);
+      }
 
       const payload = await updatePost(global, {
         id: parsed.data.id,
         slug: parsed.data.slug,
         patch,
         source,
+        params: Object.keys(emailParams).length > 0 ? emailParams : undefined,
       });
 
       if (global.json) {

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -358,10 +358,15 @@ export class GhostClient {
       });
     },
 
-    add: (post: Record<string, unknown>, source?: 'html') =>
+    add: (
+      post: Record<string, unknown>,
+      source?: 'html',
+      params?: Record<string, string | number | boolean | undefined>,
+    ) =>
       this.request<Record<string, unknown>>('POST', '/posts/', {
         body: { posts: [post] },
         source,
+        params,
       }),
 
     edit: (

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -358,15 +358,10 @@ export class GhostClient {
       });
     },
 
-    add: (
-      post: Record<string, unknown>,
-      source?: 'html',
-      params?: Record<string, string | number | boolean | undefined>,
-    ) =>
+    add: (post: Record<string, unknown>, source?: 'html') =>
       this.request<Record<string, unknown>>('POST', '/posts/', {
         body: { posts: [post] },
         source,
-        params,
       }),
 
     edit: (

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -56,9 +56,10 @@ export async function createPost(
   global: GlobalOptions,
   post: Record<string, unknown>,
   source?: 'html',
+  params?: Record<string, string | number | boolean | undefined>,
 ): Promise<Record<string, unknown>> {
   const client = await getClient(global);
-  return client.posts.add(post, source);
+  return client.posts.add(post, source, params);
 }
 
 export async function updatePost(
@@ -135,14 +136,24 @@ export async function publishPost(
     email_segment?: string;
   },
 ): Promise<Record<string, unknown>> {
+  // Ghost requires email-related fields as URL query parameters on the PUT
+  // endpoint — passing them in the JSON body has no effect. Same pattern as
+  // schedulePost below.
+  const params: Record<string, string> = {};
+  if (options?.newsletter) {
+    params.newsletter = options.newsletter;
+  }
+  if (options?.email_segment) {
+    params.email_segment = options.email_segment;
+  }
+  if (options?.email_only !== undefined) {
+    params.email_only = String(options.email_only);
+  }
+
   return updatePost(global, {
     id,
-    patch: {
-      status: 'published',
-      newsletter: options?.newsletter,
-      email_only: options?.email_only,
-      email_segment: options?.email_segment,
-    },
+    patch: { status: 'published' },
+    params: Object.keys(params).length > 0 ? params : undefined,
   });
 }
 
@@ -157,8 +168,7 @@ export async function schedulePost(
   },
 ): Promise<Record<string, unknown>> {
   // Ghost requires email-related fields as query parameters on the PUT
-  // endpoint for scheduled posts — passing them in the JSON body has no
-  // effect.  This differs from the publish transition where the body works.
+  // endpoint — same pattern as publishPost above.
   const params: Record<string, string> = {};
   if (options?.newsletter) {
     params.newsletter = options.newsletter;

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -4,6 +4,22 @@ import { ExitCode, GhstError } from './errors.js';
 import { collectAllPages } from './pagination.js';
 import type { GlobalOptions } from './types.js';
 
+export function buildEmailParams(
+  options: { newsletter?: string; email_only?: boolean; email_segment?: string } = {},
+): Record<string, string> | undefined {
+  const params: Record<string, string> = {};
+  if (options.newsletter) {
+    params.newsletter = options.newsletter;
+  }
+  if (options.email_segment) {
+    params.email_segment = options.email_segment;
+  }
+  if (options.email_only !== undefined) {
+    params.email_only = String(options.email_only);
+  }
+  return Object.keys(params).length > 0 ? params : undefined;
+}
+
 function getFirstPost(payload: Record<string, unknown>): Record<string, unknown> {
   const posts = payload.posts;
   if (!Array.isArray(posts) || posts.length === 0) {
@@ -56,10 +72,9 @@ export async function createPost(
   global: GlobalOptions,
   post: Record<string, unknown>,
   source?: 'html',
-  params?: Record<string, string | number | boolean | undefined>,
 ): Promise<Record<string, unknown>> {
   const client = await getClient(global);
-  return client.posts.add(post, source, params);
+  return client.posts.add(post, source);
 }
 
 export async function updatePost(
@@ -136,24 +151,10 @@ export async function publishPost(
     email_segment?: string;
   },
 ): Promise<Record<string, unknown>> {
-  // Ghost requires email-related fields as URL query parameters on the PUT
-  // endpoint — passing them in the JSON body has no effect. Same pattern as
-  // schedulePost below.
-  const params: Record<string, string> = {};
-  if (options?.newsletter) {
-    params.newsletter = options.newsletter;
-  }
-  if (options?.email_segment) {
-    params.email_segment = options.email_segment;
-  }
-  if (options?.email_only !== undefined) {
-    params.email_only = String(options.email_only);
-  }
-
   return updatePost(global, {
     id,
     patch: { status: 'published' },
-    params: Object.keys(params).length > 0 ? params : undefined,
+    params: buildEmailParams(options),
   });
 }
 
@@ -167,26 +168,13 @@ export async function schedulePost(
     email_segment?: string;
   },
 ): Promise<Record<string, unknown>> {
-  // Ghost requires email-related fields as query parameters on the PUT
-  // endpoint — same pattern as publishPost above.
-  const params: Record<string, string> = {};
-  if (options?.newsletter) {
-    params.newsletter = options.newsletter;
-  }
-  if (options?.email_segment) {
-    params.email_segment = options.email_segment;
-  }
-  if (options?.email_only !== undefined) {
-    params.email_only = String(options.email_only);
-  }
-
   return updatePost(global, {
     id,
     patch: {
       status: 'scheduled',
       published_at: at,
     },
-    params: Object.keys(params).length > 0 ? params : undefined,
+    params: buildEmailParams(options),
   });
 }
 

--- a/src/mcp/tools/core.ts
+++ b/src/mcp/tools/core.ts
@@ -32,6 +32,7 @@ import { listOffers } from '../../lib/offers.js';
 import { createPage, deletePage, getPage, listPages, updatePage } from '../../lib/pages.js';
 import { parseCsv } from '../../lib/parse.js';
 import {
+  buildEmailParams,
   createPost,
   deletePost,
   getPost,
@@ -608,7 +609,8 @@ export function registerCoreTools(
       'posts',
       'ghost_post_update',
       {
-        description: 'Update a Ghost post by id or slug.',
+        description:
+          'Update a Ghost post by id or slug, with optional email delivery settings on the publish transition.',
         inputSchema: z.object({
           id: z.string().optional(),
           slug: z.string().optional(),
@@ -618,6 +620,9 @@ export function registerCoreTools(
           publish_at: z.string().datetime().optional(),
           tags: z.array(z.string()).optional(),
           visibility: z.enum(['public', 'members', 'paid', 'tiers']).optional(),
+          newsletter: z.string().optional(),
+          email_only: z.boolean().optional(),
+          email_segment: z.string().optional(),
         }),
       },
       async (global, args) => {
@@ -633,6 +638,11 @@ export function registerCoreTools(
             visibility: args.visibility,
           },
           source: args.html ? 'html' : undefined,
+          params: buildEmailParams({
+            newsletter: args.newsletter,
+            email_only: args.email_only,
+            email_segment: args.email_segment,
+          }),
         });
         return toolResult(payload);
       },
@@ -663,13 +673,20 @@ export function registerCoreTools(
       'posts',
       'ghost_post_publish',
       {
-        description: 'Publish a Ghost post.',
+        description: 'Publish a Ghost post, with optional email delivery settings.',
         inputSchema: z.object({
           id: z.string(),
+          newsletter: z.string().optional(),
+          email_only: z.boolean().optional(),
+          email_segment: z.string().optional(),
         }),
       },
       async (global, args) => {
-        const payload = await publishPost(global, args.id);
+        const payload = await publishPost(global, args.id, {
+          newsletter: args.newsletter,
+          email_only: args.email_only,
+          email_segment: args.email_segment,
+        });
         return toolResult(payload);
       },
     );

--- a/src/schemas/post.ts
+++ b/src/schemas/post.ts
@@ -70,9 +70,6 @@ export const PostCreateInputSchema = withSingleContentSource(
       ogTitle: z.string().optional(),
       ogImage: z.string().url().optional(),
       codeInjectionHead: z.string().optional(),
-      newsletter: z.string().optional(),
-      emailOnly: z.boolean().optional(),
-      emailSegment: z.string().optional(),
     })
     .refine((data) => Boolean(data.title || data.fromJson), {
       message: 'Provide --title or --from-json.',

--- a/tests/commands-and-run.test.ts
+++ b/tests/commands-and-run.test.ts
@@ -2021,6 +2021,157 @@ describe('run + commands', () => {
     expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"email_segment"');
   });
 
+  test('post publish forwards email delivery flags as query params', async () => {
+    const putRequests: Array<{ url: URL; body: Record<string, unknown> }> = [];
+
+    installGhostFixtureFetchMock({
+      onRequest: ({ pathname, method, url, init }) => {
+        if (method === 'PUT' && pathname.endsWith(`/ghost/api/admin/posts/${fixtureIds.postId}/`)) {
+          putRequests.push({
+            url: new URL(url.toString()),
+            body: JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>,
+          });
+        }
+
+        return undefined;
+      },
+    });
+
+    await expect(
+      run([
+        'node',
+        'ghst',
+        '--url',
+        'https://myblog.ghost.io',
+        '--staff-token',
+        KEY,
+        'post',
+        'publish',
+        fixtureIds.postId,
+        '--newsletter',
+        'weekly',
+        '--email-only',
+        '--email-segment',
+        'status:paid',
+        '--json',
+      ]),
+    ).resolves.toBe(ExitCode.SUCCESS);
+
+    expect(putRequests).toHaveLength(1);
+    expect(putRequests[0]?.url.searchParams.get('newsletter')).toBe('weekly');
+    expect(putRequests[0]?.url.searchParams.get('email_only')).toBe('true');
+    expect(putRequests[0]?.url.searchParams.get('email_segment')).toBe('status:paid');
+    expect(putRequests[0]?.body).toMatchObject({
+      posts: [
+        {
+          status: 'published',
+          updated_at: expect.any(String),
+        },
+      ],
+    });
+    expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"newsletter"');
+    expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"email_only"');
+    expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"email_segment"');
+  });
+
+  test('post update forwards email delivery flags as query params', async () => {
+    const putRequests: Array<{ url: URL; body: Record<string, unknown> }> = [];
+
+    installGhostFixtureFetchMock({
+      onRequest: ({ pathname, method, url, init }) => {
+        if (method === 'PUT' && pathname.endsWith(`/ghost/api/admin/posts/${fixtureIds.postId}/`)) {
+          putRequests.push({
+            url: new URL(url.toString()),
+            body: JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>,
+          });
+        }
+
+        return undefined;
+      },
+    });
+
+    await expect(
+      run([
+        'node',
+        'ghst',
+        '--url',
+        'https://myblog.ghost.io',
+        '--staff-token',
+        KEY,
+        'post',
+        'update',
+        fixtureIds.postId,
+        '--title',
+        'Updated',
+        '--status',
+        'published',
+        '--newsletter',
+        'weekly',
+        '--email-only',
+        'true',
+        '--email-segment',
+        'status:paid',
+        '--json',
+      ]),
+    ).resolves.toBe(ExitCode.SUCCESS);
+
+    expect(putRequests).toHaveLength(1);
+    expect(putRequests[0]?.url.searchParams.get('newsletter')).toBe('weekly');
+    expect(putRequests[0]?.url.searchParams.get('email_only')).toBe('true');
+    expect(putRequests[0]?.url.searchParams.get('email_segment')).toBe('status:paid');
+    expect(putRequests[0]?.body).toMatchObject({
+      posts: [
+        {
+          title: 'Updated',
+          status: 'published',
+          updated_at: expect.any(String),
+        },
+      ],
+    });
+    expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"newsletter"');
+    expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"email_only"');
+    expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"email_segment"');
+  });
+
+  test('post update accepts --email-only false to unset the flag', async () => {
+    const putRequests: Array<{ url: URL; body: Record<string, unknown> }> = [];
+
+    installGhostFixtureFetchMock({
+      onRequest: ({ pathname, method, url, init }) => {
+        if (method === 'PUT' && pathname.endsWith(`/ghost/api/admin/posts/${fixtureIds.postId}/`)) {
+          putRequests.push({
+            url: new URL(url.toString()),
+            body: JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>,
+          });
+        }
+
+        return undefined;
+      },
+    });
+
+    await expect(
+      run([
+        'node',
+        'ghst',
+        '--url',
+        'https://myblog.ghost.io',
+        '--staff-token',
+        KEY,
+        'post',
+        'update',
+        fixtureIds.postId,
+        '--title',
+        'Cleared',
+        '--email-only',
+        'false',
+        '--json',
+      ]),
+    ).resolves.toBe(ExitCode.SUCCESS);
+
+    expect(putRequests).toHaveLength(1);
+    expect(putRequests[0]?.url.searchParams.get('email_only')).toBe('false');
+  });
+
   test('uses env output mode for json errors', async () => {
     process.env.GHST_OUTPUT = 'json';
     await expect(run(['node', 'ghst', 'api'])).resolves.toBe(ExitCode.USAGE_ERROR);

--- a/tests/lib-resource-services.test.ts
+++ b/tests/lib-resource-services.test.ts
@@ -50,6 +50,7 @@ import {
   updatePage,
 } from '../src/lib/pages.js';
 import {
+  buildEmailParams,
   bulkPosts,
   copyPost,
   createPost,
@@ -678,6 +679,58 @@ describe('resource service helpers', () => {
     expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"newsletter"');
     expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"email_only"');
     expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"email_segment"');
+  });
+
+  test('publishPost sends email delivery options as query params instead of request body', async () => {
+    const putRequests: Array<{ url: URL; body: Record<string, unknown> }> = [];
+
+    installGhostFixtureFetchMock({
+      onRequest: ({ pathname, method, url, init }) => {
+        if (method === 'PUT' && pathname.endsWith(`/ghost/api/admin/posts/${fixtureIds.postId}/`)) {
+          putRequests.push({
+            url: new URL(url.toString()),
+            body: JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>,
+          });
+        }
+
+        return undefined;
+      },
+    });
+
+    await expect(
+      publishPost({}, fixtureIds.postId, {
+        newsletter: 'weekly',
+        email_only: true,
+        email_segment: 'status:paid',
+      }),
+    ).resolves.toMatchObject({
+      posts: [{ id: fixtureIds.postId }],
+    });
+
+    expect(putRequests).toHaveLength(1);
+    expect(putRequests[0]?.url.searchParams.get('newsletter')).toBe('weekly');
+    expect(putRequests[0]?.url.searchParams.get('email_only')).toBe('true');
+    expect(putRequests[0]?.url.searchParams.get('email_segment')).toBe('status:paid');
+    expect(putRequests[0]?.body).toMatchObject({
+      posts: [
+        {
+          status: 'published',
+          updated_at: expect.any(String),
+        },
+      ],
+    });
+    expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"newsletter"');
+    expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"email_only"');
+    expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"email_segment"');
+  });
+
+  test('buildEmailParams omits empty options and stringifies email_only', async () => {
+    expect(buildEmailParams()).toBeUndefined();
+    expect(buildEmailParams({})).toBeUndefined();
+    expect(buildEmailParams({ newsletter: 'weekly' })).toEqual({ newsletter: 'weekly' });
+    expect(
+      buildEmailParams({ newsletter: 'weekly', email_only: false, email_segment: 'status:paid' }),
+    ).toEqual({ newsletter: 'weekly', email_only: 'false', email_segment: 'status:paid' });
   });
 
   test('returns zero-op bulk result when no resources match', async () => {

--- a/tests/mcp-core-tools.test.ts
+++ b/tests/mcp-core-tools.test.ts
@@ -763,6 +763,85 @@ describe('mcp core tool registration', () => {
     expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"email_segment"');
   });
 
+  test('ghost_post_publish forwards email delivery flags as query params', async () => {
+    const putRequests: Array<{ url: URL; body: Record<string, unknown> }> = [];
+    installGhostFixtureFetchMock({
+      onRequest: ({ pathname, method, url, init }) => {
+        if (method === 'PUT' && pathname.endsWith(`/ghost/api/admin/posts/${fixtureIds.postId}/`)) {
+          putRequests.push({
+            url: new URL(url.toString()),
+            body: JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>,
+          });
+        }
+
+        return undefined;
+      },
+    });
+
+    const { server, tools } = createRegistry();
+    registerCoreTools(server as never, {}, new Set(MCP_TOOL_GROUPS));
+    const tool = tools.get('ghost_post_publish');
+
+    expect(tool, 'Tool ghost_post_publish should be registered').toBeDefined();
+    await tool?.handler({
+      id: fixtureIds.postId,
+      newsletter: 'weekly',
+      email_only: true,
+      email_segment: 'status:paid',
+    });
+
+    expect(putRequests).toHaveLength(1);
+    expect(putRequests[0]?.url.searchParams.get('newsletter')).toBe('weekly');
+    expect(putRequests[0]?.url.searchParams.get('email_only')).toBe('true');
+    expect(putRequests[0]?.url.searchParams.get('email_segment')).toBe('status:paid');
+    expect(putRequests[0]?.body).toMatchObject({
+      posts: [{ status: 'published', updated_at: expect.any(String) }],
+    });
+    expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"newsletter"');
+    expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"email_only"');
+    expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"email_segment"');
+  });
+
+  test('ghost_post_update forwards email delivery flags as query params', async () => {
+    const putRequests: Array<{ url: URL; body: Record<string, unknown> }> = [];
+    installGhostFixtureFetchMock({
+      onRequest: ({ pathname, method, url, init }) => {
+        if (method === 'PUT' && pathname.endsWith(`/ghost/api/admin/posts/${fixtureIds.postId}/`)) {
+          putRequests.push({
+            url: new URL(url.toString()),
+            body: JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>,
+          });
+        }
+
+        return undefined;
+      },
+    });
+
+    const { server, tools } = createRegistry();
+    registerCoreTools(server as never, {}, new Set(MCP_TOOL_GROUPS));
+    const tool = tools.get('ghost_post_update');
+
+    expect(tool, 'Tool ghost_post_update should be registered').toBeDefined();
+    await tool?.handler({
+      id: fixtureIds.postId,
+      status: 'published',
+      newsletter: 'weekly',
+      email_only: true,
+      email_segment: 'status:paid',
+    });
+
+    expect(putRequests).toHaveLength(1);
+    expect(putRequests[0]?.url.searchParams.get('newsletter')).toBe('weekly');
+    expect(putRequests[0]?.url.searchParams.get('email_only')).toBe('true');
+    expect(putRequests[0]?.url.searchParams.get('email_segment')).toBe('status:paid');
+    expect(putRequests[0]?.body).toMatchObject({
+      posts: [{ status: 'published', updated_at: expect.any(String) }],
+    });
+    expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"newsletter"');
+    expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"email_only"');
+    expect(JSON.stringify(putRequests[0]?.body ?? {})).not.toContain('"email_segment"');
+  });
+
   test('can register a narrow tool subset', () => {
     const { server, tools } = createRegistry();
     registerCoreTools(server as never, {}, new Set<McpToolGroup>(['site']));


### PR DESCRIPTION
## Describe the problem you are solving

This PR fixes a silent bug where `ghst post publish --newsletter <slug>` (and the equivalent flow via `post update --status published --newsletter <slug>`) does not trigger Ghost's email-on-publish pipeline. The CLI accepts the flags, but their values land in the JSON body of the request, where Ghost's Admin API silently ignores them. Ghost requires `newsletter`, `email_segment`, and `email_only` as **URL query parameters** on the PUT to `/posts/{id}/`.

`schedulePost` was the only path doing it correctly — it already builds a `params` object and routes them through the URL. This PR aligns `publishPost` and the `update` command's action with that pattern, extracts a shared `buildEmailParams` helper, and brings the MCP `ghost_post_publish` tool to feature parity with `ghost_post_schedule` (it previously accepted no email options).

A second, coupled change: `--newsletter`, `--email-only`, and `--email-segment` removed from `post create`. Verified empirically (and via source trace, details in Notes) that Ghost's POST endpoint doesn't fire email — the flags were dead code that misled users. The README's "Create and publish" example moves the flags onto `post publish` accordingly.

Verified end-to-end against a local Ghost 6.39 dev instance:
- Before the fix: `post publish --newsletter <slug>` returns `email: null` on the post.
- After the fix: same call returns `email: { status: 'submitting', email_count: <N>, newsletter_id: <id>, recipient_filter: 'all', ... }`.
- After the create-flag removal: `post create --newsletter <slug>` correctly errors with `unknown option '--newsletter'` rather than silently accepting the flag and doing nothing.

## Changelog for devs

* Fixed `ghst post publish --newsletter <slug>` so it actually triggers the newsletter email (was being sent as a JSON body field, where Ghost silently ignored it; now sent as a URL query param)
* Fixed `ghst post update --status published --newsletter <slug>` for the same underlying reason
* Removed `--newsletter`, `--email-only`, `--email-segment` from `post create` (CLI flag, zod schema, and downstream plumbing). They were no-ops since Ghost's POST `/posts/` does not invoke the email pipeline at all — verified via source trace through `postEmailHandler.createOrRetryEmail`. Keeping them would have continued misleading users.
* Updated the README's "Create and publish" example to put email flags on `post publish` (where they actually work) instead of `post create`
* Added `buildEmailParams` helper in `src/lib/posts.ts`, exported for the command-side actions. Replaces a 9-line builder that was duplicated across `publishPost`, `schedulePost`, and the `update` command action.
* MCP: `ghost_post_publish` and `ghost_post_update` tools now accept `newsletter`, `email_only`, and `email_segment` (mirroring `ghost_post_schedule`). Without this, MCP clients had no way to trigger email-on-publish via either tool.
* Unified the `--newsletter` / `--email-segment` help-text descriptions across `post publish`, `post schedule`, and `post update` — three commands previously had three different short descriptions for the same flag.
* Added 7 new tests: 3 end-to-end (`commands-and-run`) covering publish + update + the `--email-only false` handling on update; 2 unit-level (`lib-resource-services`) covering `publishPost` and `buildEmailParams`; 2 MCP-level (`mcp-core-tools`) covering `ghost_post_publish` and `ghost_post_update`.

## Changelog for customers

* Fixed: `ghst post publish --newsletter <slug>` now sends the newsletter email. Previously the post would publish to the website but no email went out.
* Fixed: `ghst post update --status published --newsletter <slug>` likewise triggers the email when transitioning a draft to published.
* Removed: `--newsletter`, `--email-only`, `--email-segment` are no longer accepted on `ghst post create`. They were silently no-ops (Ghost's POST endpoint never fires email). Use `ghst post publish` (or `post schedule` / `post update`) with these flags instead.

## Notes

* **Root cause**: a wrong inline comment in `src/lib/posts.ts` before this PR — `schedulePost`'s "This differs from the publish transition where the body works" was the false assumption that drove `publishPost`'s implementation. `schedulePost` itself was correct; `publishPost` was implemented around the wrong premise.
* **Why we removed the create flags, double-sourced**: Ghost's email pipeline runs only after `models.Post.edit()` (`postEmailHandler.createOrRetryEmail` at `posts-service.js:68`); `models.Post.add()` has no equivalent. Empirically confirmed against Ghost 6.39: `POST /posts/?newsletter=X` (status:draft) doesn't persist `newsletter_id` on the draft, and a bare `PUT status=published` then sends no email. The architectural separation is deliberate, so removing the flags is correct.
* `--email-only` on `post update` is `<value>` (accepts `true`/`false`), while `post publish` / `post schedule` are boolean flags. The repo's direction of travel has been toward boolean (commit `60025e5` flipped schedule from `<value>` to match publish), so this is a pre-existing inconsistency rather than a deliberate design. Left as-is for this PR: `parseBooleanFlag` handles both shapes, and a partial PATCH has a real use case for explicit-false ("clear a previously-set `email_only`"). Included a test for the `--email-only false` case so the current behaviour is now pinned.
* **`post update --newsletter X` on an already-published post does not re-send email** — Ghost's `shouldSendEmail` gates on the draft→published transition (`previous` must not already be `published`/`sent`). Verified empirically: email record id is unchanged across an `update --newsletter` call on a published post.

## Technical debt

None introduced.

## PR Scope (mark all that apply)

- [x] Improves the user experience
- [x] Enhances the readability of our code
- [x] Simplifies the maintenance of our software
- [x] Fixes a bug
- [ ] Provide a core layer to allow one of the points above

## Checklist before requesting a review (mark all that apply)

- [x] I have performed a self-review of my code
- [x] It's simple enough
- [ ] The PR is not extensive
- [x] It includes documentation
- [x] I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
