### PR TITLE
Add automatic browser-session login on macOS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ pnpm build
 - `comment get` uses Ghost Admin's moderation read include set, and `comment thread` mirrors the Admin moderation sidebar by combining the selected comment read with the filtered thread query.
 - `comment hide|show|delete` map to Ghost Admin comment status transitions (`hidden`, `published`, `deleted`).
 - Destructive commands require the global `--enable-destructive-actions` flag; `--yes` only skips confirmation where confirmation is still required.
+- `auth login` on macOS offers to import a staff token from a browser you are already signed into Ghost with (Chromium-family, Firefox, and Safari): it verifies discovered sessions with a read-only request and only mints the token for the one you pick. `--no-browser-session` forces the manual paste flow; the lookup is macOS-only and the flag is a no-op on other platforms.
 - `auth logout` requires `--enable-destructive-actions` when removing configured sites and confirmation when removing all configured sites; non-interactive all-site removal also requires `--yes`.
 - `auth link` requires `--enable-destructive-actions` and confirmation before replacing an existing project link; non-interactive use requires `--yes`, and relinking updates the discovered project config within the enclosing repo.
 - Interactive destructive confirmations emit `GHST_AGENT_NOTICE:` lines on stderr instructing cooperative agents to ask the user for approval before continuing.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ Interactive auth flow:
 3. Create or copy a staff access token from your user profile.
 4. Paste `Ghost API URL` and `Ghost Staff Access Token`.
 
+On macOS, `ghst auth login` first offers to import a token from a browser you are
+already signed into Ghost with, so you can skip the copy/paste. Use
+`--no-browser-session` to force the manual flow. See `ghst auth login --help`.
+
 Non-interactive auth for CI/scripts:
 
 ```bash

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -2,7 +2,13 @@ import { spawn } from 'node:child_process';
 import readline from 'node:readline/promises';
 import chalk from 'chalk';
 import type { Command } from 'commander';
+import ora from 'ora';
 import { generateStaffJwt, parseStaffAccessToken } from '../lib/auth.js';
+import {
+  type DiscoveredGhostSession,
+  discoverBrowserGhostSessions,
+  mintStaffTokenForSession,
+} from '../lib/browser-auth.js';
 import { GhostClient } from '../lib/client.js';
 import {
   deriveSiteAlias,
@@ -18,7 +24,8 @@ import { credentialRefForAlias, getCredentialStore } from '../lib/credentials.js
 import { assertDestructiveActionsEnabled } from '../lib/destructive-actions.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
 import { confirmDestructiveAction } from '../lib/prompts.js';
-import { isNonInteractive } from '../lib/tty.js';
+import { selectBrowserSession } from '../lib/session-picker.js';
+import { isNonInteractive, isStdoutTty } from '../lib/tty.js';
 
 type PromptFn = (question: string) => Promise<string>;
 type OpenUrlFn = (url: string) => Promise<void>;
@@ -136,8 +143,38 @@ async function openGhostAdminForLogin(adminOrigin: string, useColor: boolean): P
 }
 /* c8 ignore stop */
 
+type BrowserSessionDiscoveryFn = (version: string) => Promise<DiscoveredGhostSession[]>;
+
+// Default discovery seam. No-op under tests so suites that don't inject never
+// read real browser stores or pop a Keychain prompt.
+function defaultBrowserSessionDiscoveryFn(version: string): Promise<DiscoveredGhostSession[]> {
+  if (process.env.VITEST) {
+    return Promise.resolve([]);
+  }
+  return discoverBrowserGhostSessions(version);
+}
+
+type BrowserSessionTokenFn = (
+  session: DiscoveredGhostSession,
+  version: string,
+) => Promise<string | null>;
+
+// Default mint seam. No-op under tests so suites that don't inject never hit the
+// network; real minting is exercised via setBrowserSessionTokenForTests.
+function defaultBrowserSessionTokenFn(
+  session: DiscoveredGhostSession,
+  version: string,
+): Promise<string | null> {
+  if (process.env.VITEST) {
+    return Promise.resolve(null);
+  }
+  return mintStaffTokenForSession(session, version);
+}
+
 let promptFn: PromptFn = prompt;
 let openUrlFn: OpenUrlFn = openExternalUrl;
+let browserSessionDiscoveryFn: BrowserSessionDiscoveryFn = defaultBrowserSessionDiscoveryFn;
+let browserSessionTokenFn: BrowserSessionTokenFn = defaultBrowserSessionTokenFn;
 
 export function setPromptForTests(nextPrompt: PromptFn | null): void {
   promptFn = nextPrompt ?? prompt;
@@ -145,6 +182,71 @@ export function setPromptForTests(nextPrompt: PromptFn | null): void {
 
 export function setOpenUrlForTests(nextOpenUrl: OpenUrlFn | null): void {
   openUrlFn = nextOpenUrl ?? openExternalUrl;
+}
+
+export function setBrowserSessionDiscoveryForTests(next: BrowserSessionDiscoveryFn | null): void {
+  browserSessionDiscoveryFn = next ?? defaultBrowserSessionDiscoveryFn;
+}
+
+export function setBrowserSessionTokenForTests(next: BrowserSessionTokenFn | null): void {
+  browserSessionTokenFn = next ?? defaultBrowserSessionTokenFn;
+}
+
+interface BrowserImport {
+  urlInput: string; // origin of the chosen session (set even if minting failed)
+  staffTokenInput?: string; // present only when the token was minted
+  imported: boolean; // true when a usable token was imported
+}
+
+// Discovery-first browser login: search for logged-in sessions, let the user
+// pick one, and mint its staff token. Returns null when there's nothing to use
+// (no sessions, or the user chose to type a URL). Throws if the user cancels.
+async function importTokenFromBrowserSession(
+  apiVersion: string,
+  useColor: boolean,
+): Promise<BrowserImport | null> {
+  const spinner =
+    process.platform === 'darwin' && isStdoutTty()
+      ? ora('Searching for Ghost sessions in your browser...').start()
+      : null;
+  const sessions = await browserSessionDiscoveryFn(apiVersion).catch(() => []);
+  // Clear the spinner either way; if nothing was found we fall through to the
+  // URL prompt silently rather than showing a negative message.
+  spinner?.stop();
+  if (sessions.length === 0) {
+    return null;
+  }
+
+  const choice = await selectBrowserSession(sessions, { useColor, prompt: promptFn });
+  /* c8 ignore start -- cancel only reachable from the interactive selector */
+  if (choice === 'cancel') {
+    throw new GhstError('Operation cancelled.', {
+      exitCode: ExitCode.OPERATION_CANCELLED,
+      code: 'OPERATION_CANCELLED',
+    });
+  }
+  /* c8 ignore stop */
+  if (choice === 'url') {
+    return null;
+  }
+
+  // Mint the durable token only now, for the chosen session — the same
+  // create-if-absent the user's profile page does when they proceed.
+  const token = await browserSessionTokenFn(choice, apiVersion).catch(() => null);
+  if (!token) {
+    // Verified during discovery but minting failed (rare); keep the chosen
+    // origin so the user lands on the right site's manual flow.
+    /* c8 ignore next */
+    return { urlInput: choice.origin, imported: false };
+  }
+
+  const who = choice.user ? ` (${choice.user})` : '';
+  const message = `Imported your staff access token from ${choice.source}${who}`;
+  console.log('');
+  console.log(
+    useColor ? message.replace('staff access token', chalk.yellow('staff access token')) : message,
+  );
+  return { urlInput: choice.origin, staffTokenInput: token, imported: true };
 }
 
 function printLoginGuidance(useColor: boolean): void {
@@ -385,6 +487,10 @@ export function registerAuthCommands(program: Command): void {
     .option('--staff-token-env <name>', 'Read staff token from env var name')
     .option('--non-interactive', 'Disable prompts and require explicit credentials')
     .option(
+      '--no-browser-session',
+      'Skip importing a staff token from a logged-in browser session (macOS)',
+    )
+    .option(
       '--insecure-storage',
       'Allow plaintext credential storage when secure storage is unavailable',
     )
@@ -405,6 +511,21 @@ export function registerAuthCommands(program: Command): void {
         : undefined;
       let urlInput = options.url || global.url;
       let staffTokenInput = options.staffToken || global.staffToken || envStaffTokenInput;
+      const browserEnabled = options.browserSession !== false;
+      const apiVersion = process.env.GHOST_API_VERSION ?? 'v6.0';
+
+      // Discovery-first: when no URL/token was supplied, offer the logged-in
+      // browser sessions we can find so the user can pick one instead of typing
+      // a URL. Opt-out via --no-browser-session; falls through if none found.
+      let importedFromBrowser = false;
+      if (!nonInteractive && !urlInput && !staffTokenInput && browserEnabled) {
+        const result = await importTokenFromBrowserSession(apiVersion, global.color !== false);
+        if (result) {
+          urlInput = result.urlInput;
+          staffTokenInput = result.staffTokenInput ?? staffTokenInput;
+          importedFromBrowser = result.imported;
+        }
+      }
 
       if (nonInteractive) {
         if (!urlInput || !staffTokenInput) {
@@ -416,39 +537,42 @@ export function registerAuthCommands(program: Command): void {
             },
           );
         }
-      } else {
-        urlInput = urlInput || (await promptFn('Ghost URL (e.g. https://example.com): '));
+      } else if (!urlInput) {
+        urlInput = await promptFn('Ghost URL (e.g. https://example.com): ');
       }
 
-      const requestedOrigin = normalizeGhostUrl(urlInput ?? '');
-      const resolvedOrigin = await resolveGhostAdminOrigin(requestedOrigin);
-      urlInput = resolvedOrigin.resolvedOrigin;
+      // A discovered origin is already verified, so skip the redirect probe.
+      if (!importedFromBrowser) {
+        const requestedOrigin = normalizeGhostUrl(urlInput ?? '');
+        const resolvedOrigin = await resolveGhostAdminOrigin(requestedOrigin);
+        urlInput = resolvedOrigin.resolvedOrigin;
 
-      if (hasOriginChanged(resolvedOrigin.inputOrigin, resolvedOrigin.resolvedOrigin)) {
-        if (nonInteractive) {
-          throw new GhstError(
-            `Ghost Admin discovery resolved to '${resolvedOrigin.resolvedOrigin}' instead of '${resolvedOrigin.inputOrigin}'. Re-run with --url ${resolvedOrigin.resolvedOrigin}.`,
-            {
-              exitCode: ExitCode.USAGE_ERROR,
-              code: 'USAGE_ERROR',
-            },
+        if (hasOriginChanged(resolvedOrigin.inputOrigin, resolvedOrigin.resolvedOrigin)) {
+          if (nonInteractive) {
+            throw new GhstError(
+              `Ghost Admin discovery resolved to '${resolvedOrigin.resolvedOrigin}' instead of '${resolvedOrigin.inputOrigin}'. Re-run with --url ${resolvedOrigin.resolvedOrigin}.`,
+              {
+                exitCode: ExitCode.USAGE_ERROR,
+                code: 'USAGE_ERROR',
+              },
+            );
+          }
+
+          const shouldContinue = await confirmRedirectedOrigin(
+            resolvedOrigin.inputOrigin,
+            resolvedOrigin.resolvedOrigin,
+            global.color !== false,
           );
-        }
-
-        const shouldContinue = await confirmRedirectedOrigin(
-          resolvedOrigin.inputOrigin,
-          resolvedOrigin.resolvedOrigin,
-          global.color !== false,
-        );
-        if (!shouldContinue) {
-          throw new GhstError('Operation cancelled.', {
-            exitCode: ExitCode.OPERATION_CANCELLED,
-            code: 'OPERATION_CANCELLED',
-          });
+          if (!shouldContinue) {
+            throw new GhstError('Operation cancelled.', {
+              exitCode: ExitCode.OPERATION_CANCELLED,
+              code: 'OPERATION_CANCELLED',
+            });
+          }
         }
       }
 
-      if (!nonInteractive) {
+      if (!nonInteractive && !importedFromBrowser) {
         printLoginGuidance(global.color !== false);
         await promptFn('Press Enter to Continue...');
         await openGhostAdminForLogin(urlInput, global.color !== false);
@@ -457,18 +581,40 @@ export function registerAuthCommands(program: Command): void {
         }
       }
 
-      parseStaffAccessToken(staffTokenInput);
-
-      const client = new GhostClient({
-        url: urlInput,
-        staffToken: staffTokenInput,
-        version: process.env.GHOST_API_VERSION ?? 'v6.0',
-      });
-
-      await client.siteInfo();
+      try {
+        parseStaffAccessToken(staffTokenInput);
+        await new GhostClient({
+          url: urlInput,
+          staffToken: staffTokenInput,
+          version: apiVersion,
+        }).siteInfo();
+      } catch (error) {
+        // An auto-imported token that fails validation (e.g. it expired between
+        // read and use) must not be worse than the manual flow, so fall back to
+        // the paste flow instead of failing the command.
+        if (!importedFromBrowser || nonInteractive) {
+          throw error;
+        }
+        const notice = 'That browser session could not be used; continue in Ghost Admin instead.';
+        console.log('');
+        console.log(global.color === false ? notice : chalk.yellow(notice));
+        importedFromBrowser = false;
+        printLoginGuidance(global.color !== false);
+        await promptFn('Press Enter to Continue...');
+        await openGhostAdminForLogin(urlInput, global.color !== false);
+        staffTokenInput = await promptFn('Ghost Staff Access Token: ');
+        parseStaffAccessToken(staffTokenInput);
+        await new GhostClient({
+          url: urlInput,
+          staffToken: staffTokenInput,
+          version: apiVersion,
+        }).siteInfo();
+      }
 
       const config = await readUserConfig();
-      const alias = options.site ?? deriveSiteAlias(urlInput);
+      // `--site` is declared both globally and on this subcommand; honour
+      // either placement before falling back to deriving from the URL.
+      const alias = options.site ?? global.site ?? deriveSiteAlias(urlInput);
       const persisted = await persistSiteCredential(
         alias,
         staffTokenInput,

--- a/src/lib/browser-auth.ts
+++ b/src/lib/browser-auth.ts
@@ -1,0 +1,194 @@
+import { StaffAccessTokenSchema } from '../schemas/common.js';
+import { type DiscoveredCookie, discoverBrowserSessionCookies } from './browser-cookies.js';
+
+// Bootstraps a durable staff access token from an already-logged-in Ghost Admin
+// browser session. The session cookie is only a bootstrap: we use it once on a
+// GET to mint the persistent {id}:{secret} token the CLI stores, then discard
+// it. The cookie is never persisted and never becomes the auth primitive.
+
+const SESSION_COOKIE_NAME = 'ghost-admin-api-session';
+const STAFF_TOKEN_PATH = '/ghost/api/admin/users/me/token/';
+
+// Per-request cap so an unreachable or slow host can't stall discovery. A
+// candidate that times out is simply skipped.
+const REQUEST_TIMEOUT_MS = 8000;
+
+type SessionDiscoverer = (name: string) => DiscoveredCookie[];
+
+let sessionDiscoverer: SessionDiscoverer = discoverBrowserSessionCookies;
+
+// Test seam: swap the discovery source so the picker logic can be tested
+// without touching real browser stores or the Keychain.
+export function setSessionDiscovererForTests(discoverer: SessionDiscoverer | null): void {
+  sessionDiscoverer = discoverer ?? discoverBrowserSessionCookies;
+}
+
+// GETs an admin endpoint with the session cookie and returns the parsed JSON,
+// or null on any failure (network error, timeout, non-OK, or unparseable body).
+// Shared by the verify and mint requests, which differ only in path and shape.
+async function getWithSession(
+  path: string,
+  origin: string,
+  cookieValue: string,
+  version: string,
+): Promise<unknown> {
+  try {
+    const response = await fetch(new URL(path, origin).toString(), {
+      method: 'GET',
+      headers: {
+        'Accept-Version': version,
+        'App-Pragma': 'no-cache',
+        Cookie: `${SESSION_COOKIE_NAME}=${cookieValue}`,
+      },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      return null;
+    }
+    return await response.json();
+  } catch {
+    return null; // network error, timeout, or unparseable body
+  }
+}
+
+async function exchangeCookieForStaffToken(
+  origin: string,
+  cookieValue: string,
+  version: string,
+): Promise<string | null> {
+  const body = (await getWithSession(STAFF_TOKEN_PATH, origin, cookieValue, version)) as {
+    apiKey?: { id?: unknown; secret?: unknown };
+  } | null;
+  const apiKey = body?.apiKey;
+  if (!apiKey || typeof apiKey.id !== 'string' || typeof apiKey.secret !== 'string') {
+    return null;
+  }
+  const token = `${apiKey.id}:${apiKey.secret}`;
+  return StaffAccessTokenSchema.safeParse(token).success ? token : null;
+}
+
+// A logged-in Ghost site discovered from a browser session. Discovery only
+// verifies the session (a read-only GET /users/me/); the durable staff token is
+// minted later, via mintStaffTokenForSession, once the user actually picks this
+// session — mirroring the manual flow where the token is created only when the
+// user proceeds. The cookie value is carried so we can mint at that point; it is
+// never persisted.
+export interface DiscoveredGhostSession {
+  origin: string; // verified Ghost Admin origin
+  label: string; // host (or host:port) for display
+  source: string; // browser/profile it came from
+  user: string | null; // the signed-in user's name/email, if resolvable
+  cookieValue: string; // session cookie, used to mint the token once chosen
+}
+
+// Builds the origin(s) to try for a discovered cookie. The cookie store knows
+// the host but not the port, so localhost defaults to Ghost's dev port.
+function candidateOrigins(cookie: DiscoveredCookie): string[] {
+  if (cookie.host === 'localhost' || cookie.host === '127.0.0.1') {
+    return [`http://${cookie.host}:2368`];
+  }
+  return [cookie.secure ? `https://${cookie.host}` : `http://${cookie.host}`];
+}
+
+function firstNonEmptyString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+// Verifies a session cookie against an origin with a read-only GET /users/me/
+// (which does NOT create a staff token), returning the signed-in user's
+// name/email and id, or null if the cookie isn't a valid Ghost Admin session.
+async function fetchSessionUser(
+  origin: string,
+  cookieValue: string,
+  version: string,
+): Promise<{ name: string | null; id: string } | null> {
+  const body = (await getWithSession(
+    '/ghost/api/admin/users/me/',
+    origin,
+    cookieValue,
+    version,
+  )) as {
+    users?: Array<{ id?: unknown; name?: unknown; email?: unknown }>;
+  } | null;
+  const user = body?.users?.[0];
+  if (!user || typeof user.id !== 'string') {
+    return null; // not a valid Ghost Admin session (or unexpected body shape)
+  }
+  return { name: firstNonEmptyString(user.name, user.email), id: user.id };
+}
+
+// Discovers logged-in Ghost sessions across the local browsers and verifies each
+// with a read-only request (no staff token is created here). Returns one entry
+// per usable session; never throws.
+export async function discoverBrowserGhostSessions(
+  version: string,
+): Promise<DiscoveredGhostSession[]> {
+  let cookies: DiscoveredCookie[];
+  try {
+    cookies = sessionDiscoverer(SESSION_COOKIE_NAME);
+  } catch {
+    return [];
+  }
+
+  // Verify every candidate concurrently so the wall-clock cost is one round
+  // trip, not the sum across sites. Order is preserved from discovery.
+  const verified = await Promise.all(
+    cookies.map(async (cookie) => {
+      for (const origin of candidateOrigins(cookie)) {
+        const info = await fetchSessionUser(origin, cookie.value, version);
+        if (!info) {
+          continue;
+        }
+        let label: string;
+        try {
+          label = new URL(origin).host;
+        } catch {
+          label = origin;
+        }
+        return {
+          session: {
+            origin,
+            label,
+            source: cookie.source,
+            user: info.name,
+            cookieValue: cookie.value,
+          },
+          userId: info.id,
+        };
+      }
+      return null;
+    }),
+  );
+
+  // Dedupe the same user on the same site across browsers/profiles (different
+  // cookies, same account) so the picker doesn't list a site twice.
+  const sessions: DiscoveredGhostSession[] = [];
+  const seen = new Set<string>();
+  for (const entry of verified) {
+    if (!entry) {
+      continue;
+    }
+    const key = `${entry.session.origin} ${entry.userId}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    sessions.push(entry.session);
+  }
+  return sessions;
+}
+
+// Mints (or fetches, if it already exists) the durable staff token for a chosen
+// session by calling GET /users/me/token/, which creates-if-absent — the same
+// thing the user's profile page does. Returns {id}:{secret}, or null on failure.
+export async function mintStaffTokenForSession(
+  session: DiscoveredGhostSession,
+  version: string,
+): Promise<string | null> {
+  return exchangeCookieForStaffToken(session.origin, session.cookieValue, version);
+}

--- a/src/lib/browser-cookies.ts
+++ b/src/lib/browser-cookies.ts
@@ -1,0 +1,491 @@
+import { execFileSync } from 'node:child_process';
+import { createDecipheriv, pbkdf2Sync } from 'node:crypto';
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// A cookie found by scanning every host (used to discover sites the user is
+// logged in to without knowing the URL up front).
+export interface DiscoveredCookie {
+  host: string; // leading-dot stripped, e.g. "localhost" or "demo.ghost.io"
+  secure: boolean; // whether the cookie was flagged Secure (https)
+  value: string;
+  source: string;
+}
+
+// A cookie parsed out of Safari's binary cookie store.
+export interface SafariCookieRecord {
+  host: string;
+  name: string;
+  value: string;
+  secure: boolean;
+}
+
+// macOS-only helper that reads a cookie out of the local browser stores so the
+// CLI can bootstrap auth from an already-logged-in Ghost Admin session instead
+// of asking the user to copy a token by hand. It only ever reads; the cookie is
+// used once by the caller and never persisted.
+//
+// kooky (the Go library this mirrors) has no good Node equivalent, so the
+// macOS Chromium path is ported directly: copy the (locked) SQLite store, read
+// it via the sqlite3 CLI, fetch the AES key via the signed `security` CLI, and
+// decrypt the v10 values ourselves. Firefox stores values in plaintext.
+
+const HOME = os.homedir();
+const SUPPORT = path.join(HOME, 'Library', 'Application Support');
+
+// Chromium-family browsers share the v10 scheme, the profile layout, and a
+// "<name> Safe Storage" Keychain key; only the store dir and key name differ.
+interface ChromiumBrowser {
+  name: string;
+  dir: string; // under ~/Library/Application Support
+  keychain: string; // Keychain service holding the AES password
+}
+
+const CHROMIUM_BROWSERS: ChromiumBrowser[] = [
+  { name: 'Chrome', dir: 'Google/Chrome', keychain: 'Chrome Safe Storage' },
+  { name: 'Brave', dir: 'BraveSoftware/Brave-Browser', keychain: 'Brave Safe Storage' },
+  { name: 'Edge', dir: 'Microsoft Edge', keychain: 'Microsoft Edge Safe Storage' },
+  { name: 'Vivaldi', dir: 'Vivaldi', keychain: 'Vivaldi Safe Storage' },
+  { name: 'Arc', dir: 'Arc/User Data', keychain: 'Arc Safe Storage' },
+  { name: 'Opera', dir: 'com.operasoftware.Opera', keychain: 'Opera Safe Storage' },
+  { name: 'Opera GX', dir: 'com.operasoftware.OperaGX', keychain: 'Opera Safe Storage' },
+];
+
+/* c8 ignore start -- macOS-only browser store IO; verified by the manual login flow */
+function sqlEscape(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+function runSqlite(dbFile: string, query: string): string | null {
+  try {
+    return execFileSync('sqlite3', [dbFile, query], {
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+    });
+  } catch {
+    return null;
+  }
+}
+
+// Copies a (possibly locked) store to a temp file and runs fn against the copy,
+// cleaning up afterwards. Returns null when the source is unreadable.
+function withTempCopy<T>(src: string, fn: (tmpFile: string) => T): T | null {
+  let data: Buffer;
+  try {
+    data = readFileSync(src);
+  } catch {
+    return null;
+  }
+
+  let dir: string;
+  try {
+    dir = mkdtempSync(path.join(os.tmpdir(), 'ghst-ck-'));
+  } catch {
+    return null;
+  }
+
+  const tmp = path.join(dir, 'store.sqlite');
+  try {
+    writeFileSync(tmp, data);
+    return fn(tmp);
+  } catch {
+    return null;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function chromiumProfileDirs(base: string): string[] {
+  let profiles: string[];
+  try {
+    profiles = readdirSync(base, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .filter((name) => name === 'Default' || name.startsWith('Profile '));
+  } catch {
+    return [];
+  }
+  if (profiles.length > 0) {
+    return profiles;
+  }
+  // Some Chromium browsers (e.g. Opera) store cookies in the base dir directly
+  // rather than under a "Default" profile. Treat the base as a single profile.
+  for (const sub of ['Network/Cookies', 'Cookies']) {
+    try {
+      statSync(path.join(base, sub));
+      return ['.'];
+    } catch {
+      // keep looking
+    }
+  }
+  return [];
+}
+
+// Resolves a profile dir ("Default", "Profile 1") to its friendly name from the
+// browser's Local State, falling back to the dir name.
+function chromiumProfileName(base: string, dir: string): string {
+  if (dir === '.') {
+    return 'Default';
+  }
+  try {
+    const localState = JSON.parse(readFileSync(path.join(base, 'Local State'), 'utf8')) as {
+      profile?: { info_cache?: Record<string, { name?: string }> };
+    };
+    const name = localState.profile?.info_cache?.[dir]?.name;
+    if (typeof name === 'string' && name.length > 0) {
+      return name;
+    }
+  } catch {
+    // Local State missing or unparseable — fall back to the dir name.
+  }
+  return dir;
+}
+
+// Derives the AES-128 key a Chromium browser uses for cookie values from the
+// Keychain password (PBKDF2, salt "saltysalt", 1003 iters). Returns null when
+// the key is unavailable (e.g. the user denied the prompt).
+function chromiumSafeStorageKey(service: string): Buffer | null {
+  let password: string;
+  try {
+    password = execFileSync('security', ['find-generic-password', '-w', '-s', service], {
+      encoding: 'utf8',
+    }).replace(/\n+$/, '');
+  } catch {
+    return null;
+  }
+  return pbkdf2Sync(password, 'saltysalt', 1003, 16, 'sha1');
+}
+/* c8 ignore stop */
+
+function decodeUtf8Strict(buffer: Buffer): string | null {
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(buffer);
+  } catch {
+    return null;
+  }
+}
+
+// Decrypts a "v10" AES-128-CBC cookie value (IV = 16 spaces), stripping PKCS7
+// padding and the 32-byte SHA256(host) prefix recent Chromium prepends.
+export function decryptChromiumCookieV10(enc: Buffer, key: Buffer): string | null {
+  if (enc.length < 3 + 16 || enc.subarray(0, 3).toString('latin1') !== 'v10') {
+    return null;
+  }
+
+  const ciphertext = enc.subarray(3);
+  if (ciphertext.length % 16 !== 0) {
+    return null;
+  }
+
+  let plaintext: Buffer;
+  try {
+    const decipher = createDecipheriv('aes-128-cbc', key, Buffer.alloc(16, 0x20));
+    decipher.setAutoPadding(false);
+    plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  } catch {
+    return null;
+  }
+
+  const pad = plaintext[plaintext.length - 1] ?? 0;
+  if (pad >= 1 && pad <= 16 && pad <= plaintext.length) {
+    plaintext = plaintext.subarray(0, plaintext.length - pad);
+  }
+
+  // Recent Chromium prepends a 32-byte SHA256(host); strip it when the full
+  // buffer isn't valid UTF-8 but the remainder is.
+  const direct = decodeUtf8Strict(plaintext);
+  if (direct !== null) {
+    return direct;
+  }
+  if (plaintext.length >= 32) {
+    return decodeUtf8Strict(plaintext.subarray(32));
+  }
+  return null;
+}
+
+function readCString(buffer: Buffer, start: number, limit: number): string | null {
+  if (start < 0 || start >= limit) {
+    return null;
+  }
+  let end = start;
+  while (end < limit && buffer[end] !== 0) {
+    end += 1;
+  }
+  return buffer.toString('utf8', start, end);
+}
+
+// Parses one page of Safari's binary cookie store, appending records to out.
+function parseSafariPage(
+  buffer: Buffer,
+  pageStart: number,
+  pageSize: number,
+  out: SafariCookieRecord[],
+): void {
+  const pageEnd = Math.min(pageStart + pageSize, buffer.length);
+  if (pageStart + 8 > pageEnd) {
+    return;
+  }
+
+  const numCookies = buffer.readUInt32LE(pageStart + 4);
+  for (let i = 0; i < numCookies; i += 1) {
+    const offsetPos = pageStart + 8 + i * 4;
+    if (offsetPos + 4 > pageEnd) {
+      return;
+    }
+    const cookieStart = pageStart + buffer.readUInt32LE(offsetPos);
+    if (cookieStart + 56 > pageEnd) {
+      continue;
+    }
+
+    const flags = buffer.readUInt32LE(cookieStart + 8);
+    const domainOffset = buffer.readUInt32LE(cookieStart + 16);
+    const nameOffset = buffer.readUInt32LE(cookieStart + 20);
+    const valueOffset = buffer.readUInt32LE(cookieStart + 28);
+
+    const host = readCString(buffer, cookieStart + domainOffset, pageEnd);
+    const name = readCString(buffer, cookieStart + nameOffset, pageEnd);
+    const value = readCString(buffer, cookieStart + valueOffset, pageEnd);
+    if (host === null || name === null || value === null) {
+      continue;
+    }
+    out.push({ host, name, value, secure: (flags & 1) === 1 });
+  }
+}
+
+// Parses Safari's Cookies.binarycookies format (big-endian header, little-endian
+// page/cookie records). Returns every cookie found; malformed input yields [].
+export function parseSafariBinaryCookies(buffer: Buffer): SafariCookieRecord[] {
+  const records: SafariCookieRecord[] = [];
+  try {
+    if (buffer.length < 8 || buffer.subarray(0, 4).toString('latin1') !== 'cook') {
+      return records;
+    }
+
+    const numPages = buffer.readUInt32BE(4);
+    const pageSizes: number[] = [];
+    let cursor = 8;
+    for (let i = 0; i < numPages; i += 1) {
+      if (cursor + 4 > buffer.length) {
+        return records;
+      }
+      pageSizes.push(buffer.readUInt32BE(cursor));
+      cursor += 4;
+    }
+
+    let pageStart = cursor;
+    for (const pageSize of pageSizes) {
+      parseSafariPage(buffer, pageStart, pageSize, records);
+      pageStart += pageSize;
+    }
+  } catch {
+    return records;
+  }
+  return records;
+}
+
+/* c8 ignore start -- macOS-only browser store IO; verified by the manual login flow */
+// Safari stores cookies in a binary file inside its sandboxed container (needs
+// Full Disk Access) and, on older systems, an unsandboxed legacy path.
+const SAFARI_COOKIE_PATHS = [
+  path.join(
+    HOME,
+    'Library',
+    'Containers',
+    'com.apple.Safari',
+    'Data',
+    'Library',
+    'Cookies',
+    'Cookies.binarycookies',
+  ),
+  path.join(HOME, 'Library', 'Cookies', 'Cookies.binarycookies'),
+];
+
+// Reads Safari's cookie records for a given name. Returns [] when the file is
+// missing or unreadable (e.g. Full Disk Access not granted).
+function readSafariRecords(name: string): SafariCookieRecord[] {
+  const records: SafariCookieRecord[] = [];
+  for (const file of SAFARI_COOKIE_PATHS) {
+    let data: Buffer;
+    try {
+      data = readFileSync(file);
+    } catch {
+      continue; // not present, or no Full Disk Access — skip silently
+    }
+    for (const record of parseSafariBinaryCookies(data)) {
+      if (record.name === name) {
+        records.push(record);
+      }
+    }
+  }
+  return records;
+}
+
+function discoverSafariCookies(name: string): DiscoveredCookie[] {
+  return readSafariRecords(name).map((record) => ({
+    host: normalizeHost(record.host),
+    secure: record.secure,
+    value: record.value,
+    source: 'Safari',
+  }));
+}
+
+function normalizeHost(host: string): string {
+  return host.startsWith('.') ? host.slice(1) : host;
+}
+
+interface DiscoveryRow {
+  host: string;
+  secure: boolean;
+  enc: Buffer;
+}
+
+// Reads every row for a cookie name across all hosts (no host filter) so we can
+// surface the sites the user is logged in to.
+function chromiumDiscoveryRows(dbFile: string, name: string): DiscoveryRow[] {
+  const out = runSqlite(
+    dbFile,
+    `SELECT host_key || char(9) || is_secure || char(9) || hex(encrypted_value) FROM cookies WHERE name = '${sqlEscape(name)}';`,
+  );
+  if (!out) {
+    return [];
+  }
+
+  const rows: DiscoveryRow[] = [];
+  for (const line of out.split('\n')) {
+    const parts = line.split('\t');
+    if (parts.length < 3) {
+      continue;
+    }
+    const host = normalizeHost((parts[0] ?? '').trim());
+    const hex = (parts[2] ?? '').trim();
+    if (host.length === 0 || hex.length === 0) {
+      continue;
+    }
+    rows.push({ host, secure: (parts[1] ?? '').trim() === '1', enc: Buffer.from(hex, 'hex') });
+  }
+  return rows;
+}
+
+function discoverChromiumCookies(name: string): DiscoveredCookie[] {
+  const results: DiscoveredCookie[] = [];
+
+  for (const browser of CHROMIUM_BROWSERS) {
+    const base = path.join(SUPPORT, browser.dir);
+    try {
+      statSync(base);
+    } catch {
+      continue;
+    }
+
+    const loggedIn: Array<{ profile: string; rows: DiscoveryRow[] }> = [];
+    for (const profile of chromiumProfileDirs(base)) {
+      const rows: DiscoveryRow[] = [];
+      for (const sub of ['Network/Cookies', 'Cookies']) {
+        const found =
+          withTempCopy(path.join(base, profile, sub), (tmp) => chromiumDiscoveryRows(tmp, name)) ??
+          [];
+        rows.push(...found);
+      }
+      if (rows.length > 0) {
+        loggedIn.push({ profile, rows });
+      }
+    }
+    if (loggedIn.length === 0) {
+      continue;
+    }
+
+    const key = chromiumSafeStorageKey(browser.keychain);
+    if (!key) {
+      continue;
+    }
+    try {
+      for (const { profile, rows } of loggedIn) {
+        for (const row of rows) {
+          const value = decryptChromiumCookieV10(row.enc, key);
+          if (value) {
+            results.push({
+              host: row.host,
+              secure: row.secure,
+              value,
+              source: `${browser.name} · ${chromiumProfileName(base, profile)}`,
+            });
+          }
+        }
+      }
+    } finally {
+      key.fill(0);
+    }
+  }
+
+  return results;
+}
+
+function discoverFirefoxCookies(name: string): DiscoveredCookie[] {
+  const profilesBase = path.join(SUPPORT, 'Firefox', 'Profiles');
+  let profiles: string[];
+  try {
+    profiles = readdirSync(profilesBase, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+
+  const results: DiscoveredCookie[] = [];
+  for (const profile of profiles) {
+    const out = withTempCopy(path.join(profilesBase, profile, 'cookies.sqlite'), (tmp) =>
+      runSqlite(
+        tmp,
+        `SELECT host || char(9) || isSecure || char(9) || value FROM moz_cookies WHERE name = '${sqlEscape(name)}';`,
+      ),
+    );
+    if (!out) {
+      continue;
+    }
+    for (const line of out.split('\n')) {
+      const parts = line.split('\t');
+      if (parts.length < 3) {
+        continue;
+      }
+      const host = normalizeHost((parts[0] ?? '').trim());
+      const value = parts.slice(2).join('\t').trim();
+      if (host.length === 0 || value.length === 0) {
+        continue;
+      }
+      results.push({
+        host,
+        secure: (parts[1] ?? '').trim() === '1',
+        value,
+        source: `Firefox · ${profile}`,
+      });
+    }
+  }
+  return results;
+}
+
+// Finds every logged-in copy of the named cookie across browser stores, without
+// needing a host up front. macOS only; returns [] everywhere else.
+export function discoverBrowserSessionCookies(name: string): DiscoveredCookie[] {
+  if (process.platform !== 'darwin') {
+    return [];
+  }
+
+  const all = [
+    ...discoverChromiumCookies(name),
+    ...discoverFirefoxCookies(name),
+    ...discoverSafariCookies(name),
+  ];
+  const seen = new Set<string>();
+  const out: DiscoveredCookie[] = [];
+  for (const cookie of all) {
+    const key = `${cookie.source} ${cookie.host} ${cookie.value}`;
+    if (cookie.value.length === 0 || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    out.push(cookie);
+  }
+  return out;
+}
+/* c8 ignore stop */

--- a/src/lib/session-picker.ts
+++ b/src/lib/session-picker.ts
@@ -1,0 +1,157 @@
+import chalk from 'chalk';
+import type { DiscoveredGhostSession } from './browser-auth.js';
+import { isStdinTty, isStdoutTty } from './tty.js';
+
+// Interactive picker for the Ghost sessions discovered in the user's browsers.
+// Uses an arrow-key selector on a TTY and falls back to a numbered prompt
+// otherwise (pipes, CI, tests). Kept out of the auth command to keep that
+// handler focused on the login flow rather than terminal UI.
+
+// Outcome of the picker: a chosen session, "url" to type a URL instead, or
+// "cancel" to abort the login.
+export type SessionChoice = DiscoveredGhostSession | 'url' | 'cancel';
+
+type Prompt = (question: string) => Promise<string>;
+
+const BANNER_BORDER = '------------------------------------------------------------';
+const BANNER_TITLE = 'Continue From Your Browser';
+const URL_OPTION_LABEL = 'Enter a Ghost URL manually';
+
+function sessionRow(session: DiscoveredGhostSession): string {
+  const who = session.user ? ` — ${session.user}` : '';
+  return `${session.label}${who} (${session.source})`;
+}
+
+function printBanner(count: number, useColor: boolean): void {
+  const noun = `${count} active Ghost session${count === 1 ? '' : 's'}`;
+  console.log('');
+  console.log(BANNER_BORDER);
+  console.log(BANNER_TITLE);
+  console.log(BANNER_BORDER);
+  console.log(`Found ${useColor ? chalk.yellow(noun) : noun}:`);
+  console.log('');
+}
+
+// Numbered prompt used when stdin/stdout isn't a TTY (pipes, CI, tests).
+async function numberedSelect(
+  sessions: DiscoveredGhostSession[],
+  prompt: Prompt,
+): Promise<SessionChoice> {
+  sessions.forEach((session, index) => {
+    console.log(`  ${index + 1}) ${sessionRow(session)}`);
+  });
+  console.log('');
+  const answer = await prompt(
+    `Select a session [1-${sessions.length}], or press Enter to type a URL: `,
+  );
+  const trimmed = answer.trim();
+  if (!trimmed) {
+    return 'url';
+  }
+  const choice = Number.parseInt(trimmed, 10);
+  if (Number.isInteger(choice) && choice >= 1 && choice <= sessions.length) {
+    return sessions[choice - 1] ?? 'url';
+  }
+  return 'url';
+}
+
+/* c8 ignore start -- interactive raw-mode selector; verified by the manual login flow */
+// Arrow-key selector built on raw stdin (no extra deps): up/down to move, Enter
+// to select, Esc/Ctrl+C to cancel. "Enter a Ghost URL manually" is the last row.
+async function arrowSelect(
+  sessions: DiscoveredGhostSession[],
+  useColor: boolean,
+): Promise<SessionChoice> {
+  const labels = [...sessions.map(sessionRow), URL_OPTION_LABEL];
+  const rows = labels.map((label, i) => `${i + 1}) ${label}`);
+  const urlIndex = rows.length - 1;
+  let index = 0;
+
+  const hint = 'Use up/down or a number, Enter to select, Esc to cancel';
+  console.log(useColor ? chalk.dim(hint) : hint);
+  console.log('');
+
+  const stdin = process.stdin;
+  const stdout = process.stdout;
+
+  const renderRow = (row: string, selected: boolean): string => {
+    if (selected) {
+      const line = `> ${row}`;
+      return useColor ? chalk.cyan(line) : line;
+    }
+    return `  ${row}`;
+  };
+
+  const draw = (first: boolean): void => {
+    if (!first) {
+      stdout.write(`\x1B[${rows.length}A`); // move cursor back to the first row
+    }
+    for (let i = 0; i < rows.length; i += 1) {
+      stdout.write(`\x1B[2K${renderRow(rows[i] ?? '', i === index)}\n`);
+    }
+  };
+
+  if (stdin.isTTY) {
+    stdin.setRawMode(true);
+  }
+  stdin.resume();
+  stdout.write('\x1B[?25l'); // hide cursor
+  draw(true);
+
+  return await new Promise<SessionChoice>((resolve) => {
+    function finish(result: SessionChoice): void {
+      stdin.off('data', onData);
+      stdout.write('\x1B[?25h'); // show cursor
+      if (stdin.isTTY) {
+        stdin.setRawMode(false);
+      }
+      stdin.pause();
+      resolve(result);
+    }
+
+    function onData(chunk: Buffer): void {
+      const byte = chunk[0];
+      const isEsc = byte === 0x1b;
+      if (chunk.length === 1 && byte === 0x03) {
+        finish('cancel'); // Ctrl+C
+      } else if (chunk.length >= 3 && isEsc && chunk[1] === 0x5b && chunk[2] === 0x41) {
+        index = (index - 1 + rows.length) % rows.length;
+        draw(false);
+      } else if (chunk.length >= 3 && isEsc && chunk[1] === 0x5b && chunk[2] === 0x42) {
+        index = (index + 1) % rows.length;
+        draw(false);
+      } else if (chunk.length === 1 && byte === 0x6b) {
+        index = (index - 1 + rows.length) % rows.length;
+        draw(false);
+      } else if (chunk.length === 1 && byte === 0x6a) {
+        index = (index + 1) % rows.length;
+        draw(false);
+      } else if (chunk.length === 1 && byte !== undefined && byte >= 0x31 && byte <= 0x39) {
+        const pick = byte - 0x31; // '1' selects the first row
+        if (pick < rows.length) {
+          index = pick;
+          finish(index === urlIndex ? 'url' : (sessions[index] ?? 'url'));
+        }
+      } else if (chunk.length === 1 && (byte === 0x0d || byte === 0x0a)) {
+        finish(index === urlIndex ? 'url' : (sessions[index] ?? 'url'));
+      } else if (chunk.length === 1 && isEsc) {
+        finish('cancel'); // lone Esc, after arrow sequences
+      }
+    }
+    stdin.on('data', onData);
+  });
+}
+/* c8 ignore stop */
+
+// Shows the discovered sessions and returns the user's choice.
+export async function selectBrowserSession(
+  sessions: DiscoveredGhostSession[],
+  options: { useColor: boolean; prompt: Prompt },
+): Promise<SessionChoice> {
+  printBanner(sessions.length, options.useColor);
+  if (isStdinTty() && isStdoutTty()) {
+    /* c8 ignore next */
+    return arrowSelect(sessions, options.useColor);
+  }
+  return numberedSelect(sessions, options.prompt);
+}

--- a/tests/browser-auth.test.ts
+++ b/tests/browser-auth.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+  type DiscoveredGhostSession,
+  discoverBrowserGhostSessions,
+  mintStaffTokenForSession,
+  setSessionDiscovererForTests,
+} from '../src/lib/browser-auth.js';
+
+const ID = 'abc123';
+const SECRET = '00112233445566778899aabbccddeeff';
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+afterEach(() => {
+  setSessionDiscovererForTests(null);
+  vi.restoreAllMocks();
+});
+
+describe('discoverBrowserGhostSessions', () => {
+  test('verifies a session with a read-only request (no token minted) and labels it', async () => {
+    setSessionDiscovererForTests(() => [
+      { host: 'localhost', secure: false, value: 's%3Asess.sig', source: 'Chrome · Renato' },
+    ]);
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/users/me/')) {
+        return jsonResponse({ users: [{ id: 'u1', name: 'Renato Costa' }] });
+      }
+      return new Response('not found', { status: 404 });
+    });
+
+    const sessions = await discoverBrowserGhostSessions('v6.0');
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toEqual({
+      origin: 'http://localhost:2368',
+      label: 'localhost:2368',
+      source: 'Chrome · Renato',
+      user: 'Renato Costa',
+      cookieValue: 's%3Asess.sig',
+    });
+    // Discovery must NOT create a staff token; it only reads /users/me/.
+    expect(fetchMock.mock.calls.every(([url]) => !String(url).endsWith('/users/me/token/'))).toBe(
+      true,
+    );
+  });
+
+  test('uses https for a secure cookie and falls back to email for the label', async () => {
+    setSessionDiscovererForTests(() => [
+      { host: 'demo.ghost.io', secure: true, value: 'ok', source: 'Firefox · default' },
+    ]);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ users: [{ id: 'u1', email: 'renato@ghost.org' }] }),
+    );
+
+    const sessions = await discoverBrowserGhostSessions('v6.0');
+
+    expect(sessions[0]?.origin).toBe('https://demo.ghost.io');
+    expect(sessions[0]?.user).toBe('renato@ghost.org');
+  });
+
+  test('keeps a verified session even when no name/email is resolvable', async () => {
+    setSessionDiscovererForTests(() => [
+      { host: 'demo.ghost.io', secure: true, value: 'ok', source: 'Chrome · Renato' },
+    ]);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ users: [{ id: 'u1' }] }));
+
+    const sessions = await discoverBrowserGhostSessions('v6.0');
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.user).toBeNull();
+  });
+
+  test('dedupes the same account on the same site across browsers', async () => {
+    setSessionDiscovererForTests(() => [
+      { host: 'localhost', secure: false, value: 'chrome-cookie', source: 'Chrome · Renato' },
+      { host: 'localhost', secure: false, value: 'safari-cookie', source: 'Safari' },
+    ]);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ users: [{ id: 'same-user', name: 'Renato' }] }),
+    );
+
+    const sessions = await discoverBrowserGhostSessions('v6.0');
+
+    expect(sessions).toHaveLength(1);
+  });
+
+  test('skips cookies that fail verification', async () => {
+    setSessionDiscovererForTests(() => [
+      { host: 'demo.ghost.io', secure: true, value: 'stale', source: 'Chrome · Renato' },
+    ]);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('forbidden', { status: 403 }));
+
+    const sessions = await discoverBrowserGhostSessions('v6.0');
+
+    expect(sessions).toEqual([]);
+  });
+
+  test('returns [] and does not throw when discovery fails', async () => {
+    setSessionDiscovererForTests(() => {
+      throw new Error('keychain denied');
+    });
+    const sessions = await discoverBrowserGhostSessions('v6.0');
+    expect(sessions).toEqual([]);
+  });
+});
+
+describe('mintStaffTokenForSession', () => {
+  const session: DiscoveredGhostSession = {
+    origin: 'http://localhost:2368',
+    label: 'localhost:2368',
+    source: 'Chrome · Renato',
+    user: 'Renato Costa',
+    cookieValue: 's%3Asess.sig',
+  };
+
+  test('mints the durable token for a chosen session', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(jsonResponse({ apiKey: { id: ID, secret: SECRET } }));
+
+    const token = await mintStaffTokenForSession(session, 'v6.0');
+
+    expect(token).toBe(`${ID}:${SECRET}`);
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toBe('http://localhost:2368/ghost/api/admin/users/me/token/');
+    expect((init?.headers as Record<string, string>).Cookie).toBe(
+      'ghost-admin-api-session=s%3Asess.sig',
+    );
+  });
+
+  test('returns null when minting fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('forbidden', { status: 403 }));
+    const token = await mintStaffTokenForSession(session, 'v6.0');
+    expect(token).toBeNull();
+  });
+
+  test('returns null when the response has no usable apiKey', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ apiKey: { id: ID } }));
+    const token = await mintStaffTokenForSession(session, 'v6.0');
+    expect(token).toBeNull();
+  });
+
+  test('returns null and does not throw on network failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
+    const token = await mintStaffTokenForSession(session, 'v6.0');
+    expect(token).toBeNull();
+  });
+});

--- a/tests/browser-cookies.test.ts
+++ b/tests/browser-cookies.test.ts
@@ -1,0 +1,144 @@
+import { createCipheriv, pbkdf2Sync } from 'node:crypto';
+import { describe, expect, test } from 'vitest';
+import {
+  decryptChromiumCookieV10,
+  discoverBrowserSessionCookies,
+  parseSafariBinaryCookies,
+} from '../src/lib/browser-cookies.js';
+
+const key = pbkdf2Sync('test-pass', 'saltysalt', 1003, 16, 'sha1');
+
+function encryptV10(plaintext: Buffer): Buffer {
+  const cipher = createCipheriv('aes-128-cbc', key, Buffer.alloc(16, 0x20));
+  return Buffer.concat([Buffer.from('v10'), cipher.update(plaintext), cipher.final()]);
+}
+
+describe('decryptChromiumCookieV10', () => {
+  test('round-trips a v10 cookie value', () => {
+    const enc = encryptV10(Buffer.from('s%3Asession-id.signature'));
+    expect(decryptChromiumCookieV10(enc, key)).toBe('s%3Asession-id.signature');
+  });
+
+  test('strips the 32-byte sha256(host) prefix recent Chromium prepends', () => {
+    const enc = encryptV10(Buffer.concat([Buffer.alloc(32, 0xff), Buffer.from('s%3Avalue.sig')]));
+    expect(decryptChromiumCookieV10(enc, key)).toBe('s%3Avalue.sig');
+  });
+
+  test('returns null for non-v10 payloads', () => {
+    expect(decryptChromiumCookieV10(Buffer.from('not-a-v10-encrypted-cookie'), key)).toBeNull();
+  });
+
+  test('returns null when decrypted with the wrong key', () => {
+    const enc = encryptV10(Buffer.from('s%3Aa-reasonably-long-session-value.signature-bytes'));
+    const wrong = pbkdf2Sync('other-pass', 'saltysalt', 1003, 16, 'sha1');
+    expect(decryptChromiumCookieV10(enc, wrong)).toBeNull();
+  });
+});
+
+// Minimal encoders for Safari's binarycookies format, mirroring the parser.
+interface TestCookie {
+  host: string;
+  name: string;
+  value: string;
+  secure: boolean;
+}
+
+function encodeSafariCookie(cookie: TestCookie): Buffer {
+  const domain = Buffer.from(`${cookie.host}\0`, 'utf8');
+  const name = Buffer.from(`${cookie.name}\0`, 'utf8');
+  const pathBuf = Buffer.from('/\0', 'utf8');
+  const value = Buffer.from(`${cookie.value}\0`, 'utf8');
+
+  const domainOffset = 56;
+  const nameOffset = domainOffset + domain.length;
+  const pathOffset = nameOffset + name.length;
+  const valueOffset = pathOffset + pathBuf.length;
+  const size = valueOffset + value.length;
+
+  const buf = Buffer.alloc(size);
+  buf.writeUInt32LE(size, 0);
+  buf.writeUInt32LE(cookie.secure ? 1 : 0, 8);
+  buf.writeUInt32LE(domainOffset, 16);
+  buf.writeUInt32LE(nameOffset, 20);
+  buf.writeUInt32LE(pathOffset, 24);
+  buf.writeUInt32LE(valueOffset, 28);
+  domain.copy(buf, domainOffset);
+  name.copy(buf, nameOffset);
+  pathBuf.copy(buf, pathOffset);
+  value.copy(buf, valueOffset);
+  return buf;
+}
+
+function encodeSafariPage(cookies: Buffer[]): Buffer {
+  const headerLen = 8 + cookies.length * 4 + 4;
+  const offsets: number[] = [];
+  let running = headerLen;
+  for (const cookie of cookies) {
+    offsets.push(running);
+    running += cookie.length;
+  }
+  const page = Buffer.alloc(running);
+  page.writeUInt32BE(0x00000100, 0);
+  page.writeUInt32LE(cookies.length, 4);
+  offsets.forEach((offset, i) => {
+    page.writeUInt32LE(offset, 8 + i * 4);
+  });
+  let pos = headerLen;
+  for (const cookie of cookies) {
+    cookie.copy(page, pos);
+    pos += cookie.length;
+  }
+  return page;
+}
+
+function encodeSafariBinaryCookies(cookies: TestCookie[]): Buffer {
+  const page = encodeSafariPage(cookies.map(encodeSafariCookie));
+  const header = Buffer.alloc(8 + 4);
+  header.write('cook', 0, 'latin1');
+  header.writeUInt32BE(1, 4);
+  header.writeUInt32BE(page.length, 8);
+  return Buffer.concat([header, page, Buffer.alloc(8)]);
+}
+
+describe('parseSafariBinaryCookies', () => {
+  test('parses host, name, value and secure flag', () => {
+    const buffer = encodeSafariBinaryCookies([
+      { host: 'localhost', name: 'ghost-admin-api-session', value: 's%3Asess.sig', secure: false },
+      {
+        host: '.demo.ghost.io',
+        name: 'ghost-admin-api-session',
+        value: 's%3Aother.sig',
+        secure: true,
+      },
+    ]);
+
+    const records = parseSafariBinaryCookies(buffer);
+
+    expect(records).toEqual([
+      { host: 'localhost', name: 'ghost-admin-api-session', value: 's%3Asess.sig', secure: false },
+      {
+        host: '.demo.ghost.io',
+        name: 'ghost-admin-api-session',
+        value: 's%3Aother.sig',
+        secure: true,
+      },
+    ]);
+  });
+
+  test('returns [] for non-Safari payloads', () => {
+    expect(parseSafariBinaryCookies(Buffer.from('not binarycookies'))).toEqual([]);
+  });
+
+  test('returns [] for truncated input without throwing', () => {
+    expect(parseSafariBinaryCookies(Buffer.from('cook'))).toEqual([]);
+  });
+});
+
+describe('discoverBrowserSessionCookies', () => {
+  test('returns nothing on non-macOS platforms', () => {
+    if (process.platform === 'darwin') {
+      return; // platform-gated behaviour only asserted off-darwin
+    }
+    expect(discoverBrowserSessionCookies('ghost-admin-api-session')).toEqual([]);
+  });
+});

--- a/tests/commands-and-run.test.ts
+++ b/tests/commands-and-run.test.ts
@@ -2,7 +2,12 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { setOpenUrlForTests, setPromptForTests } from '../src/commands/auth.js';
+import {
+  setBrowserSessionDiscoveryForTests,
+  setBrowserSessionTokenForTests,
+  setOpenUrlForTests,
+  setPromptForTests,
+} from '../src/commands/auth.js';
 import { setMcpRunnersForTests } from '../src/commands/mcp.js';
 import { setThemeDevRunnerForTests, setThemeValidatorForTests } from '../src/commands/theme.js';
 import { setWebhookListenRunnerForTests } from '../src/commands/webhook.js';
@@ -68,6 +73,8 @@ describe('run + commands', () => {
   afterEach(async () => {
     setPromptForTests(null);
     setOpenUrlForTests(null);
+    setBrowserSessionDiscoveryForTests(null);
+    setBrowserSessionTokenForTests(null);
     setPromptHandlerForTests(null);
     setMcpRunnersForTests(null);
     setThemeDevRunnerForTests(null);
@@ -259,6 +266,112 @@ describe('run + commands', () => {
     expect(openedUrls).toEqual(['https://prompted.ghost.io/ghost/#/my-profile']);
 
     delete process.env.MY_GHOST_KEY;
+  });
+
+  test('lists discovered browser sessions and logs in with the selected one', async () => {
+    const openedUrls: string[] = [];
+    setOpenUrlForTests(async (url) => {
+      openedUrls.push(url);
+    });
+    const prompts: string[] = [];
+    setPromptForTests(async (question) => {
+      prompts.push(question);
+      return '1';
+    });
+    setBrowserSessionDiscoveryForTests(async () => [
+      {
+        origin: 'https://picked.ghost.io',
+        label: 'picked.ghost.io',
+        source: 'Chrome · Renato',
+        user: 'Renato',
+        cookieValue: 's%3Apicked.sig',
+      },
+      {
+        origin: 'http://localhost:2368',
+        label: 'localhost:2368',
+        source: 'Chrome · Renato',
+        user: 'Renato',
+        cookieValue: 's%3Alocal.sig',
+      },
+    ]);
+    // The token is minted only after the user picks a session.
+    setBrowserSessionTokenForTests(async () => KEY);
+
+    await expect(run(['node', 'ghst', 'auth', 'login'])).resolves.toBe(ExitCode.SUCCESS);
+
+    // Picked a session, so no URL prompt, no "Press Enter", no profile open.
+    expect(openedUrls).toEqual([]);
+    expect(prompts).toEqual(['Select a session [1-2], or press Enter to type a URL: ']);
+  });
+
+  test('falls back to typing a URL when no discovered session is selected', async () => {
+    const openedUrls: string[] = [];
+    setOpenUrlForTests(async (url) => {
+      openedUrls.push(url);
+    });
+    setBrowserSessionDiscoveryForTests(async () => [
+      {
+        origin: 'https://picked.ghost.io',
+        label: 'picked.ghost.io',
+        source: 'Chrome · Renato',
+        user: null,
+        cookieValue: 's%3Apicked.sig',
+      },
+    ]);
+    // Picker selection (Enter = type a URL), URL, "Press Enter", token.
+    const answers = ['', 'https://typed.ghost.io', '', KEY];
+    setPromptForTests(async () => answers.shift() ?? '');
+
+    await expect(run(['node', 'ghst', 'auth', 'login'])).resolves.toBe(ExitCode.SUCCESS);
+    expect(openedUrls).toEqual(['https://typed.ghost.io/ghost/#/my-profile']);
+  });
+
+  test('skips the browser import with --no-browser-session and uses the paste flow', async () => {
+    const openedUrls: string[] = [];
+    setOpenUrlForTests(async (url) => {
+      openedUrls.push(url);
+    });
+    // Even though a session is discoverable, --no-browser-session skips it.
+    setBrowserSessionDiscoveryForTests(async () => [
+      {
+        origin: 'https://nobrowser.ghost.io',
+        label: 'nobrowser.ghost.io',
+        source: 'Chrome · Renato',
+        user: 'Renato',
+        cookieValue: 's%3Ax.sig',
+      },
+    ]);
+    const answers = ['https://nobrowser.ghost.io', '', KEY];
+    setPromptForTests(async () => answers.shift() ?? '');
+
+    await expect(run(['node', 'ghst', 'auth', 'login', '--no-browser-session'])).resolves.toBe(
+      ExitCode.SUCCESS,
+    );
+    expect(openedUrls).toEqual(['https://nobrowser.ghost.io/ghost/#/my-profile']);
+  });
+
+  test('falls back to the paste flow when an imported token fails validation', async () => {
+    const openedUrls: string[] = [];
+    setOpenUrlForTests(async (url) => {
+      openedUrls.push(url);
+    });
+    setBrowserSessionDiscoveryForTests(async () => [
+      {
+        origin: 'http://localhost:2368',
+        label: 'localhost:2368',
+        source: 'Chrome · Renato',
+        user: 'Renato',
+        cookieValue: 's%3Ax.sig',
+      },
+    ]);
+    // The minted token is invalid, so validation throws and we fall back.
+    setBrowserSessionTokenForTests(async () => 'not-a-valid-token');
+    // Picker selection, then the manual paste flow: "Press Enter", token.
+    const answers = ['1', '', KEY];
+    setPromptForTests(async () => answers.shift() ?? '');
+
+    await expect(run(['node', 'ghst', 'auth', 'login'])).resolves.toBe(ExitCode.SUCCESS);
+    expect(openedUrls).toEqual(['http://localhost:2368/ghost/#/my-profile']);
   });
 
   test('shows project link in auth list while leaving auth status unchanged', async () => {

--- a/tests/session-picker.test.ts
+++ b/tests/session-picker.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { DiscoveredGhostSession } from '../src/lib/browser-auth.js';
+import { selectBrowserSession } from '../src/lib/session-picker.js';
+
+const sessions: DiscoveredGhostSession[] = [
+  {
+    origin: 'http://localhost:2368',
+    label: 'localhost:2368',
+    source: 'Chrome · Renato',
+    user: 'Renato',
+    cookieValue: 's%3Aa',
+  },
+  {
+    origin: 'https://demo.ghost.io',
+    label: 'demo.ghost.io',
+    source: 'Firefox · dev',
+    user: null,
+    cookieValue: 's%3Ab',
+  },
+];
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// Non-TTY (the vitest environment) exercises the numbered-prompt fallback.
+describe('selectBrowserSession (numbered fallback)', () => {
+  test('returns the chosen session by number', async () => {
+    const result = await selectBrowserSession(sessions, {
+      useColor: false,
+      prompt: async () => '2',
+    });
+    expect(result).toBe(sessions[1]);
+  });
+
+  test('returns "url" when the user presses Enter', async () => {
+    const result = await selectBrowserSession(sessions, {
+      useColor: false,
+      prompt: async () => '',
+    });
+    expect(result).toBe('url');
+  });
+
+  test('returns "url" for out-of-range or non-numeric input', async () => {
+    expect(
+      await selectBrowserSession(sessions, { useColor: false, prompt: async () => '99' }),
+    ).toBe('url');
+    expect(
+      await selectBrowserSession(sessions, { useColor: false, prompt: async () => 'abc' }),
+    ).toBe('url');
+  });
+});


### PR DESCRIPTION
## Describe the problem you are solving
This PR removes the copy/paste step from `ghst auth login` on macOS. Instead of opening Ghost Admin, copying a staff access token from your profile, and pasting it back, the CLI detects the Ghost sessions you're already signed into in your browser, lets you pick one, and imports the staff access token automatically. It falls back to the existing manual flow whenever it can't help, so the current experience never regresses.

**Linux and Windows are completely unchanged.** Discovery is macOS-only (the cookie readers return nothing off macOS), so `auth login` on other platforms behaves exactly as it does today — URL prompt then manual paste. The `--no-browser-session` flag is accepted everywhere for consistency but is a no-op outside macOS.

## Changelog for devs

* Added `src/lib/browser-cookies.ts`: macOS reader for the `ghost-admin-api-session` cookie across Chromium-family browsers (Chrome, Brave, Edge, Vivaldi, Arc, Opera/GX), Firefox, and Safari — Chromium via `sqlite3` + the `security` Keychain key + AES-v10 decrypt; Safari via a `binarycookies` parser
* Added `src/lib/browser-auth.ts`: session discovery via read-only `GET /users/me/` (deduped by user + origin) and deferred staff-token mint via `GET /users/me/token/` (create-if-absent)
* Added `src/lib/session-picker.ts`: arrow-key selector with a numbered fallback for non-TTY/CI
* Changed `auth login`: discovery-first flow that falls back to the manual paste flow (including when an imported token fails validation); added `--no-browser-session` opt-out
* Added an 8s per-request timeout and parallel verification so discovery stays fast and can't stall
* Added tests: cookie decrypt + Safari parser, discovery/verify/mint, the picker, and login integration paths
* Updated `README.md` and `AGENTS.md`

## Changelog for customers

* Added: on macOS, `ghst auth login` can sign you in automatically from a browser you're already logged into Ghost with, so you no longer have to copy and paste a staff access token

## Notes

* macOS only; Linux/Windows are unaffected and use the existing manual flow. `--no-browser-session` is accepted everywhere but only acts on macOS.
* Reading browser cookies may trigger a one-time macOS Keychain prompt (Chromium "Safe Storage"). Safari requires Full Disk Access for the terminal and is skipped silently otherwise.
* The session cookie is used once to mint the durable token and is never persisted; the derived AES key is zeroed and temp cookie-DB copies are removed (including on error).
* `GET /users/me/token/` is create-if-absent (same as opening your profile), not a rotation, so it never invalidates existing tokens. Discovery only verifies read-only; the token is minted only for the session you pick.
* Reviewed for correctness, security (no medium+ findings), and simplification before opening.

## Technical debt

* Safari needs Full Disk Access; when missing, the browser is skipped silently (intentional, matches the "no negative message" UX) with no in-CLI hint.
* localhost sessions assume the default port `2368` (the cookie store doesn't record the port); other local ports fall back to the manual URL prompt.
* The final `client.siteInfo()` validation has no request timeout (pre-existing in the shared `GhostClient`, not changed here); a fully unresponsive host could block it. Better fixed repo-wide in a separate PR.
* Not included (optional follow-ups): `--debug` diagnostics for swallowed failures; `0o600` on the temp cookie copy.

## PR Scope (mark all that apply)

- [x] Improves the user experience
- [ ] Enhances the readability of our code
- [ ] Simplifies the maintenance of our software
- [ ] Fixes a bug
- [ ] Provide a core layer to allow one of the points above

## Checklist before requesting a review (mark all that apply)

- [x] I have performed a self-review of my code
- [ ] It's simple enough
- [ ] The PR is not extensive
- [x] It includes documentation
- [x] I have added thorough tests.
- [ ] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
  - "ghst can now log you in automatically from your browser on macOS — no more copy-pasting staff tokens."
