### PR TITLE
fix: resolve CodeQL sanitization and prototype-pollution alerts

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -46,7 +46,18 @@ function getByPath(source: Record<string, unknown>, keyPath: string): unknown {
   }, source);
 }
 
-function setByPath(target: Record<string, unknown>, keyPath: string, value: unknown): void {
+const RESERVED_CONFIG_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function assertSafeConfigKey(key: string): void {
+  if (RESERVED_CONFIG_KEYS.has(key)) {
+    throw new GhstError('Invalid config path.', {
+      code: 'USAGE_ERROR',
+      exitCode: ExitCode.USAGE_ERROR,
+    });
+  }
+}
+
+export function setByPath(target: Record<string, unknown>, keyPath: string, value: unknown): void {
   const parts = keyPath.split('.');
   const leaf = parts.pop();
 
@@ -57,8 +68,11 @@ function setByPath(target: Record<string, unknown>, keyPath: string, value: unkn
     });
   }
 
+  assertSafeConfigKey(leaf);
+
   let cursor: Record<string, unknown> = target;
   for (const part of parts) {
+    assertSafeConfigKey(part);
     const next = cursor[part];
     if (typeof next !== 'object' || next === null) {
       cursor[part] = {};

--- a/src/lib/members.ts
+++ b/src/lib/members.ts
@@ -18,8 +18,8 @@ function getFirstMember(payload: Record<string, unknown>): Record<string, unknow
   return (members[0] as Record<string, unknown>) ?? {};
 }
 
-function emailFilter(email: string): string {
-  const escaped = email.replace(/'/g, "\\'");
+export function emailFilter(email: string): string {
+  const escaped = email.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
   return `email:'${escaped}'`;
 }
 

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -167,18 +167,18 @@ function rowsFromCollection(
   return collection.map((entry) => mapper((entry as Record<string, unknown>) ?? {}));
 }
 
-function stripHtml(value: unknown): string {
+export function stripHtml(value: unknown): string {
   const html = String(value ?? '');
   return html
     .replace(/<br\s*\/?>/gi, '\n')
     .replace(/<\/p>/gi, '\n')
     .replace(/<[^>]+>/g, ' ')
     .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
     .replace(/&lt;/gi, '<')
     .replace(/&gt;/gi, '>')
     .replace(/&#39;/gi, "'")
     .replace(/&quot;/gi, '"')
+    .replace(/&amp;/gi, '&')
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/src/mcp/tools/core.ts
+++ b/src/mcp/tools/core.ts
@@ -444,8 +444,8 @@ function toolResult(data: unknown): {
   };
 }
 
-function escapeNqlValue(value: string): string {
-  return value.replace(/'/g, "\\'");
+export function escapeNqlValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 }
 
 async function runSearch(

--- a/tests/sanitization.test.ts
+++ b/tests/sanitization.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest';
+import { setByPath } from '../src/commands/config.js';
+import { emailFilter } from '../src/lib/members.js';
+import { stripHtml } from '../src/lib/output.js';
+import { escapeNqlValue } from '../src/mcp/tools/core.js';
+
+describe('emailFilter NQL escaping', () => {
+  test('escapes single quotes', () => {
+    expect(emailFilter("o'brien@example.com")).toBe("email:'o\\'brien@example.com'");
+  });
+
+  test('escapes backslashes before quotes so the quote cannot break out', () => {
+    expect(emailFilter("a\\'b")).toBe("email:'a\\\\\\'b'");
+  });
+
+  test('escapes a lone backslash', () => {
+    expect(emailFilter('a\\b')).toBe("email:'a\\\\b'");
+  });
+});
+
+describe('escapeNqlValue', () => {
+  test('escapes single quotes', () => {
+    expect(escapeNqlValue("it's")).toBe("it\\'s");
+  });
+
+  test('escapes backslashes before quotes so the quote cannot break out', () => {
+    expect(escapeNqlValue("\\'")).toBe("\\\\\\'");
+  });
+});
+
+describe('stripHtml entity decoding', () => {
+  test('decodes basic entities', () => {
+    expect(stripHtml('a &amp; b')).toBe('a & b');
+    expect(stripHtml('&lt;tag&gt;')).toBe('<tag>');
+  });
+
+  test('does not double-unescape an encoded ampersand', () => {
+    expect(stripHtml('&amp;lt;')).toBe('&lt;');
+    expect(stripHtml('&amp;amp;')).toBe('&amp;');
+  });
+});
+
+describe('setByPath prototype-pollution guard', () => {
+  test('assigns nested values', () => {
+    const target: Record<string, unknown> = {};
+    setByPath(target, 'a.b.c', 1);
+    expect(target).toEqual({ a: { b: { c: 1 } } });
+  });
+
+  test('rejects __proto__ in the path', () => {
+    const target: Record<string, unknown> = {};
+    expect(() => setByPath(target, '__proto__.polluted', 'x')).toThrow();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  test('rejects constructor and prototype segments', () => {
+    expect(() => setByPath({}, 'constructor.x', 1)).toThrow();
+    expect(() => setByPath({}, 'a.prototype', 1)).toThrow();
+  });
+});


### PR DESCRIPTION
Resolves all 5 open CodeQL code-scanning alerts. All are correctness/hygiene issues with low practical exploitability for a locally-authenticated CLI, but the fixes are small and self-contained.

## Fixes

| Alert(s) | File | Issue | Fix |
|----------|------|-------|-----|
| #4, #5 | `members.ts`, `mcp/tools/core.ts` | Incomplete escaping — NQL filter builders escaped `'` but not `\`, so `\'` became `\\'` (escaped backslash + bare quote), breaking out of the quoted string | Escape `\` before `'` |
| #3 | `lib/output.ts` | Double-unescaping — `stripHtml` decoded `&amp;`→`&` before other entities, so `&amp;lt;` wrongly became `<` | Decode `&amp;` last |
| #1, #2 | `commands/config.ts` | Prototype-polluting assignment — `config set __proto__.x y` could walk onto `Object.prototype` | Reject `__proto__`/`constructor`/`prototype` path segments |

The most relevant for security is #5 (`escapeNqlValue`), which sanitizes the MCP `ghost_search` query — the least-trusted input path.

## Tests

New `tests/sanitization.test.ts` (10 cases) covers each helper directly, including the break-out and double-unescape regressions and the prototype-pollution guard. The four helpers were exported to allow direct unit testing; no change to the public CLI/MCP surface.

## Validation

- `pnpm lint` ✓
- `pnpm typecheck` ✓
- `pnpm test` — 254 passed ✓
- `pnpm build` ✓

Alerts will flip to "Fixed" once CodeQL re-scans `main` after merge.