### PR TITLE
fix: inline prototype-pollution guard so CodeQL recognizes the barrier

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -48,31 +48,26 @@ function getByPath(source: Record<string, unknown>, keyPath: string): unknown {
 
 const RESERVED_CONFIG_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
-function assertSafeConfigKey(key: string): void {
-  if (RESERVED_CONFIG_KEYS.has(key)) {
-    throw new GhstError('Invalid config path.', {
-      code: 'USAGE_ERROR',
-      exitCode: ExitCode.USAGE_ERROR,
-    });
-  }
-}
-
 export function setByPath(target: Record<string, unknown>, keyPath: string, value: unknown): void {
   const parts = keyPath.split('.');
   const leaf = parts.pop();
 
-  if (!leaf) {
+  if (!leaf || RESERVED_CONFIG_KEYS.has(leaf)) {
     throw new GhstError('Invalid config path.', {
       code: 'USAGE_ERROR',
       exitCode: ExitCode.USAGE_ERROR,
     });
   }
 
-  assertSafeConfigKey(leaf);
-
   let cursor: Record<string, unknown> = target;
   for (const part of parts) {
-    assertSafeConfigKey(part);
+    if (RESERVED_CONFIG_KEYS.has(part)) {
+      throw new GhstError('Invalid config path.', {
+        code: 'USAGE_ERROR',
+        exitCode: ExitCode.USAGE_ERROR,
+      });
+    }
+
     const next = cursor[part];
     if (typeof next !== 'object' || next === null) {
       cursor[part] = {};


### PR DESCRIPTION
Follow-up to #172. After that merged and `main` was re-scanned, the two `js/prototype-polluting-assignment` alerts (#1, #2) on `src/commands/config.ts` were **still open**.

## Why the previous fix didn't clear them

The runtime guard was correct, but it lived in a separate `assertSafeConfigKey()` helper. CodeQL's barrier-guard analysis for this query is **intraprocedural** — it doesn't follow the sanitizing check across the function boundary, so it still saw an unsanitized dataflow path from the user-controlled key into `cursor[part] = {}` and `cursor[leaf] = value`.

## Fix

Inline the `RESERVED_CONFIG_KEYS.has(...)` membership test directly inside `setByPath`, so each guard dominates its assignment sink within the same function. A `Set.has()` check is an `InclusionTest` barrier guard that CodeQL recognizes. Behaviour is unchanged.

## Tests

No new tests needed — `tests/sanitization.test.ts` from #172 already asserts `__proto__`, `constructor`, and `prototype` segments are rejected and that `Object.prototype` is not mutated. All still pass.

## Validation

- `pnpm lint` ✓
- `pnpm typecheck` ✓
- `pnpm test` — 254 passed ✓
- `pnpm build` ✓