### PR TITLE
fix: use inline equality checks for prototype-pollution guard

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -46,13 +46,11 @@ function getByPath(source: Record<string, unknown>, keyPath: string): unknown {
   }, source);
 }
 
-const RESERVED_CONFIG_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
 export function setByPath(target: Record<string, unknown>, keyPath: string, value: unknown): void {
   const parts = keyPath.split('.');
   const leaf = parts.pop();
 
-  if (!leaf || RESERVED_CONFIG_KEYS.has(leaf)) {
+  if (!leaf || leaf === '__proto__' || leaf === 'constructor' || leaf === 'prototype') {
     throw new GhstError('Invalid config path.', {
       code: 'USAGE_ERROR',
       exitCode: ExitCode.USAGE_ERROR,
@@ -61,7 +59,7 @@ export function setByPath(target: Record<string, unknown>, keyPath: string, valu
 
   let cursor: Record<string, unknown> = target;
   for (const part of parts) {
-    if (RESERVED_CONFIG_KEYS.has(part)) {
+    if (part === '__proto__' || part === 'constructor' || part === 'prototype') {
       throw new GhstError('Invalid config path.', {
         code: 'USAGE_ERROR',
         exitCode: ExitCode.USAGE_ERROR,

--- a/tests/sanitization.test.ts
+++ b/tests/sanitization.test.ts
@@ -53,6 +53,11 @@ describe('setByPath prototype-pollution guard', () => {
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
   });
 
+  test('rejects __proto__ mid-path', () => {
+    expect(() => setByPath({}, 'a.__proto__.polluted', 'x')).toThrow();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
   test('rejects constructor and prototype segments', () => {
     expect(() => setByPath({}, 'constructor.x', 1)).toThrow();
     expect(() => setByPath({}, 'a.prototype', 1)).toThrow();


### PR DESCRIPTION
Second follow-up to #172 / #173. The two `js/prototype-polluting-assignment` alerts on `src/commands/config.ts` are **still open** after #173 merged and `main` re-scanned.

## Investigation

The #173 PR scan reported **0 results**, but the post-merge full scan of `main` reported **2** — on byte-identical code (verified `git diff` between the PR head `9188f4b` and `main` is empty).

The cause: **GitHub's PR code-scanning uses diff-informed analysis**, which prunes dataflow exploration to changed lines and can under-report (false negatives). The full default-branch scan is authoritative — so #173's clean result was misleading, and the `Set.has()` membership guard was never actually recognized by CodeQL as a sanitizer barrier.

## Fix

Replace the `RESERVED_CONFIG_KEYS.has(...)` lookups with **inline `===` comparisons** against `__proto__`, `constructor`, and `prototype` — the exact sanitizer pattern from CodeQL's own qhelp for this query. Each guard is inline in `setByPath` and dominates its assignment sink (`cursor[part] = {}` and `cursor[leaf] = value`). Behaviour is unchanged.

## Tests

`tests/sanitization.test.ts` already covers first-segment, leaf, `constructor`, and `prototype` rejection; added a **mid-path `a.__proto__.x`** case. All 255 tests pass.

## Validation

- `pnpm lint` ✓
- `pnpm typecheck` ✓
- `pnpm test` — 255 passed ✓
- `pnpm build` ✓

## Note for verifying the fix

Because PR diff-informed scans can produce false negatives here, confirm against the **full `main` scan** after merge rather than the PR check.