### PR TITLE
fix: only gate raw api DELETE behind --enable-destructive-actions (#174)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ pnpm build
 - MCP tools accept an optional `site` argument for per-call targeting of configured site aliases; when omitted, existing config resolution order is preserved.
 - MCP includes `ghost_site_list` for safe configured-alias discovery without exposing stored credentials.
 - `api [endpointPath]` only accepts resource-relative paths or canonical Ghost API paths within the selected API root.
-- `api [endpointPath]` requires `--enable-destructive-actions` for non-read HTTP methods.
+- `api [endpointPath]` allows `POST`/`PUT`/`PATCH` writes by default; only `DELETE` requests require `--enable-destructive-actions`.
 - `mcp http` requires `--unsafe-public-bind` for non-loopback hosts and `--cors-origin` accepts one exact origin only.
 - MCP includes dedicated tools such as `ghost_post_schedule`, `ghost_image_upload`, `ghost_member_import`, `ghost_newsletter_list`, `ghost_tier_list`, `ghost_offer_list`, `ghost_site_list`, `ghost_theme_upload`, and `ghost_webhook_create`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ pnpm build
 - MCP tools accept an optional `site` argument for per-call targeting of configured site aliases; when omitted, existing config resolution order is preserved.
 - MCP includes `ghost_site_list` for safe configured-alias discovery without exposing stored credentials.
 - `api [endpointPath]` only accepts resource-relative paths or canonical Ghost API paths within the selected API root.
-- `api [endpointPath]` allows `POST`/`PUT`/`PATCH` writes by default; only `DELETE` requests require `--enable-destructive-actions`.
+- `api [endpointPath]` allows ordinary `POST`/`PUT`/`PATCH` writes by default; `DELETE` requests and overwrite/import routes (e.g. `POST /db/`) require `--enable-destructive-actions`.
 - `mcp http` requires `--unsafe-public-bind` for non-loopback hosts and `--cors-origin` accepts one exact origin only.
 - MCP includes dedicated tools such as `ghost_post_schedule`, `ghost_image_upload`, `ghost_member_import`, `ghost_newsletter_list`, `ghost_tier_list`, `ghost_offer_list`, `ghost_site_list`, `ghost_theme_upload`, and `ghost_webhook_create`.
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,8 @@ Direct API calls:
 
 ```bash
 ghst api /posts/ --paginate --include-headers
-ghst --enable-destructive-actions api /settings/ -X PUT -f settings[0].key=title -f settings[0].value="New title"
+ghst api /settings/ -X PUT -f settings[0].key=title -f settings[0].value="New title"
+ghst --enable-destructive-actions api /posts/<post-id>/ -X DELETE
 ```
 
 Analytics reporting:
@@ -306,7 +307,7 @@ ghst post list --json
 ghst post list --json --jq '.posts[].title'
 ```
 
-Raw `ghst api` requests using non-read HTTP methods also require `--enable-destructive-actions`.
+Raw `ghst api` requests allow `POST`/`PUT`/`PATCH` writes by default; only `DELETE` requests require `--enable-destructive-actions`.
 
 Common machine-safe practices:
 

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ ghst post list --json
 ghst post list --json --jq '.posts[].title'
 ```
 
-Raw `ghst api` requests allow `POST`/`PUT`/`PATCH` writes by default; only `DELETE` requests require `--enable-destructive-actions`.
+Raw `ghst api` requests allow ordinary `POST`/`PUT`/`PATCH` writes by default; `DELETE` requests and overwrite/import routes (e.g. `POST /db/`) require `--enable-destructive-actions`.
 
 Common machine-safe practices:
 

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -6,7 +6,7 @@ import { resolveConnectionConfig } from '../lib/config.js';
 import { getGlobalOptions } from '../lib/context.js';
 import {
   assertDestructiveActionsEnabled,
-  isDestructiveHttpMethod,
+  isDestructiveRawRequest,
 } from '../lib/destructive-actions.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
 import { printJson } from '../lib/output.js';
@@ -206,8 +206,8 @@ export function registerApiCommands(program: Command): void {
       const normalizedEndpointPath = normalizeGhostApiPath(endpointPath, requestApi);
 
       const global = getGlobalOptions(command);
-      if (isDestructiveHttpMethod(options.method)) {
-        assertDestructiveActionsEnabled(global, 'raw API delete request');
+      if (isDestructiveRawRequest({ method: options.method, path: normalizedEndpointPath })) {
+        assertDestructiveActionsEnabled(global, 'destructive raw API request');
       }
 
       const connection = await resolveConnectionConfig(global);

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -6,7 +6,7 @@ import { resolveConnectionConfig } from '../lib/config.js';
 import { getGlobalOptions } from '../lib/context.js';
 import {
   assertDestructiveActionsEnabled,
-  isReadOnlyHttpMethod,
+  isDestructiveHttpMethod,
 } from '../lib/destructive-actions.js';
 import { ExitCode, GhstError } from '../lib/errors.js';
 import { printJson } from '../lib/output.js';
@@ -206,8 +206,8 @@ export function registerApiCommands(program: Command): void {
       const normalizedEndpointPath = normalizeGhostApiPath(endpointPath, requestApi);
 
       const global = getGlobalOptions(command);
-      if (!isReadOnlyHttpMethod(options.method)) {
-        assertDestructiveActionsEnabled(global, 'raw API write request');
+      if (isDestructiveHttpMethod(options.method)) {
+        assertDestructiveActionsEnabled(global, 'raw API delete request');
       }
 
       const connection = await resolveConnectionConfig(global);

--- a/src/lib/destructive-actions.ts
+++ b/src/lib/destructive-actions.ts
@@ -18,7 +18,40 @@ export function assertDestructiveActionsEnabled(
   );
 }
 
-export function isDestructiveHttpMethod(method: string | undefined): boolean {
-  const normalized = (method ?? 'GET').toUpperCase();
-  return normalized === 'DELETE';
+function isReadOnlyHttpMethod(method: string): boolean {
+  return method === 'GET' || method === 'HEAD' || method === 'OPTIONS';
+}
+
+// Resources whose non-read writes overwrite or replace existing content
+// wholesale (e.g. `POST /db/` imports a full content archive). These are
+// destructive regardless of the HTTP verb, unlike ordinary create/update
+// writes which are allowed without the destructive flag.
+const DESTRUCTIVE_WRITE_RESOURCES = new Set(['db']);
+
+function getResourceSegment(path: string | undefined): string | null {
+  if (!path) {
+    return null;
+  }
+  const [segment] = path.split('/').filter(Boolean);
+  return segment ? segment.toLowerCase() : null;
+}
+
+// Classifies whether a raw Ghost API request needs the destructive-actions
+// guard. `DELETE` is always destructive; other writes are gated only when they
+// target an overwrite/import route. Plain `POST`/`PUT`/`PATCH` creates and
+// updates are allowed by default.
+export function isDestructiveRawRequest(options: {
+  method: string | undefined;
+  path: string | undefined;
+}): boolean {
+  const method = (options.method ?? 'GET').toUpperCase();
+  if (method === 'DELETE') {
+    return true;
+  }
+  if (isReadOnlyHttpMethod(method)) {
+    return false;
+  }
+
+  const resource = getResourceSegment(options.path);
+  return resource !== null && DESTRUCTIVE_WRITE_RESOURCES.has(resource);
 }

--- a/src/lib/destructive-actions.ts
+++ b/src/lib/destructive-actions.ts
@@ -18,7 +18,7 @@ export function assertDestructiveActionsEnabled(
   );
 }
 
-export function isReadOnlyHttpMethod(method: string | undefined): boolean {
+export function isDestructiveHttpMethod(method: string | undefined): boolean {
   const normalized = (method ?? 'GET').toUpperCase();
-  return normalized === 'GET' || normalized === 'HEAD' || normalized === 'OPTIONS';
+  return normalized === 'DELETE';
 }

--- a/src/mcp/tools/core.ts
+++ b/src/mcp/tools/core.ts
@@ -16,7 +16,7 @@ import {
 import { readUserConfig, resolveConnectionConfig } from '../../lib/config.js';
 import {
   assertDestructiveActionsEnabled,
-  isDestructiveHttpMethod,
+  isDestructiveRawRequest,
 } from '../../lib/destructive-actions.js';
 import { uploadImage } from '../../lib/images.js';
 import {
@@ -482,8 +482,12 @@ async function callApi(
     contentApi?: boolean;
   },
 ): Promise<Record<string, unknown>> {
-  if (isDestructiveHttpMethod(options.method)) {
-    assertDestructiveActionsEnabled(global, 'raw API delete request');
+  const normalizedPath = normalizeGhostApiPath(
+    options.path,
+    options.contentApi ? 'content' : 'admin',
+  );
+  if (isDestructiveRawRequest({ method: options.method, path: normalizedPath })) {
+    assertDestructiveActionsEnabled(global, 'destructive raw API request');
   }
 
   const connection = await resolveConnectionConfig(global);
@@ -495,7 +499,7 @@ async function callApi(
   });
 
   const payload = await client.rawRequest<Record<string, unknown>>(
-    normalizeGhostApiPath(options.path, options.contentApi ? 'content' : 'admin'),
+    normalizedPath,
     options.method ?? 'GET',
     options.body,
     options.params,

--- a/src/mcp/tools/core.ts
+++ b/src/mcp/tools/core.ts
@@ -16,7 +16,7 @@ import {
 import { readUserConfig, resolveConnectionConfig } from '../../lib/config.js';
 import {
   assertDestructiveActionsEnabled,
-  isReadOnlyHttpMethod,
+  isDestructiveHttpMethod,
 } from '../../lib/destructive-actions.js';
 import { uploadImage } from '../../lib/images.js';
 import {
@@ -482,8 +482,8 @@ async function callApi(
     contentApi?: boolean;
   },
 ): Promise<Record<string, unknown>> {
-  if (!isReadOnlyHttpMethod(options.method)) {
-    assertDestructiveActionsEnabled(global, 'raw API write request');
+  if (isDestructiveHttpMethod(options.method)) {
+    assertDestructiveActionsEnabled(global, 'raw API delete request');
   }
 
   const connection = await resolveConnectionConfig(global);

--- a/tests/api-command-contracts.test.ts
+++ b/tests/api-command-contracts.test.ts
@@ -79,7 +79,6 @@ describe('api command contracts', () => {
       run([
         'node',
         'ghst',
-        '--enable-destructive-actions',
         'api',
         '/posts/',
         '--method',
@@ -152,6 +151,49 @@ describe('api command contracts', () => {
         data: { site: { title: 'Demo' } },
       },
       undefined,
+    );
+  });
+
+  test('allows POST/PUT/PATCH writes without --enable-destructive-actions', async () => {
+    apiMocks.rawRequestWithMeta.mockResolvedValue({
+      status: 200,
+      headers: {},
+      data: { posts: [{ id: '1' }] },
+    });
+
+    for (const method of ['POST', 'PUT', 'PATCH']) {
+      await expect(
+        run(['node', 'ghst', 'api', '/posts/', '--method', method, '--body', '{}']),
+      ).resolves.toBe(ExitCode.SUCCESS);
+    }
+
+    expect(apiMocks.rawRequestWithMeta).toHaveBeenCalledTimes(3);
+  });
+
+  test('requires --enable-destructive-actions for DELETE requests', async () => {
+    await expect(run(['node', 'ghst', 'api', '/posts/1/', '--method', 'DELETE'])).resolves.toBe(
+      ExitCode.USAGE_ERROR,
+    );
+    expect(apiMocks.rawRequestWithMeta).not.toHaveBeenCalled();
+
+    apiMocks.rawRequestWithMeta.mockResolvedValue({ status: 204, headers: {}, data: {} });
+    await expect(
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
+        'api',
+        '/posts/1/',
+        '--method',
+        'DELETE',
+      ]),
+    ).resolves.toBe(ExitCode.SUCCESS);
+    expect(apiMocks.rawRequestWithMeta).toHaveBeenCalledWith(
+      '/posts/1/',
+      'DELETE',
+      undefined,
+      {},
+      { api: 'admin' },
     );
   });
 

--- a/tests/api-command-contracts.test.ts
+++ b/tests/api-command-contracts.test.ts
@@ -170,6 +170,28 @@ describe('api command contracts', () => {
     expect(apiMocks.rawRequestWithMeta).toHaveBeenCalledTimes(3);
   });
 
+  test('requires --enable-destructive-actions for overwrite routes like /db/ import', async () => {
+    await expect(
+      run(['node', 'ghst', 'api', '/db/', '--method', 'POST', '--body', '{}']),
+    ).resolves.toBe(ExitCode.USAGE_ERROR);
+    expect(apiMocks.rawRequestWithMeta).not.toHaveBeenCalled();
+
+    apiMocks.rawRequestWithMeta.mockResolvedValue({ status: 200, headers: {}, data: { db: [] } });
+    await expect(
+      run([
+        'node',
+        'ghst',
+        '--enable-destructive-actions',
+        'api',
+        '/db/',
+        '--method',
+        'POST',
+        '--body',
+        '{}',
+      ]),
+    ).resolves.toBe(ExitCode.SUCCESS);
+  });
+
   test('requires --enable-destructive-actions for DELETE requests', async () => {
     await expect(run(['node', 'ghst', 'api', '/posts/1/', '--method', 'DELETE'])).resolves.toBe(
       ExitCode.USAGE_ERROR,

--- a/tests/commands-and-run.test.ts
+++ b/tests/commands-and-run.test.ts
@@ -1867,17 +1867,7 @@ describe('run + commands', () => {
       run(['node', 'ghst', 'api', '/settings/', '--query', 'limit=1', 'status=published']),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
-      run([
-        'node',
-        'ghst',
-        '--enable-destructive-actions',
-        'api',
-        '/posts/',
-        '--method',
-        'POST',
-        '--input',
-        './payload.json',
-      ]),
+      run(['node', 'ghst', 'api', '/posts/', '--method', 'POST', '--input', './payload.json']),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
       run(['node', 'ghst', 'api', '/posts/', '--content-api', '--method', 'GET']),
@@ -1886,7 +1876,6 @@ describe('run + commands', () => {
       run([
         'node',
         'ghst',
-        '--enable-destructive-actions',
         'api',
         '/posts/',
         '--method',
@@ -1904,17 +1893,7 @@ describe('run + commands', () => {
       ExitCode.SUCCESS,
     );
     await expect(
-      run([
-        'node',
-        'ghst',
-        '--enable-destructive-actions',
-        'api',
-        '/posts/',
-        '--method',
-        'POST',
-        '--field',
-        'status=draft',
-      ]),
+      run(['node', 'ghst', 'api', '/posts/', '--method', 'POST', '--field', 'status=draft']),
     ).resolves.toBe(ExitCode.SUCCESS);
     await expect(
       run(['node', 'ghst', 'api', '/posts/', '--body', '{}', '--input', './payload.json']),
@@ -2272,7 +2251,7 @@ describe('run + commands', () => {
       ExitCode.USAGE_ERROR,
     );
     await expect(
-      run(['node', 'ghst', 'api', '/posts/', '--method', 'POST', '--body', '{}']),
+      run(['node', 'ghst', 'api', `/posts/${fixtureIds.postId}/`, '--method', 'DELETE']),
     ).resolves.toBe(ExitCode.USAGE_ERROR);
     await expect(
       run(['node', 'ghst', 'page', 'bulk', '--filter', 'status:draft', '--action', 'update']),

--- a/tests/mcp-core-tools.test.ts
+++ b/tests/mcp-core-tools.test.ts
@@ -687,9 +687,8 @@ describe('mcp core tool registration', () => {
 
     await expect(
       apiTool?.handler({
-        path: '/posts/',
-        method: 'POST',
-        body: { posts: [{ title: 'Blocked' }] },
+        path: `/posts/${fixtureIds.postId}/`,
+        method: 'DELETE',
       }) as Promise<unknown> | undefined,
     ).rejects.toThrow('Destructive actions are disabled');
   });


### PR DESCRIPTION
Fixes #174.

## Problem

`ghst api` refused **non-destructive** writes (`POST`/`PUT`/`PATCH`) unless `--enable-destructive-actions` was passed. Creating or updating a resource isn't destructive — only `DELETE` should be gated, consistent with the typed commands (`post create`/`update` work without the flag; only `post delete` requires it).

## Fix

Classify by HTTP method: only `DELETE` requires `--enable-destructive-actions`. `POST`/`PUT`/`PATCH` succeed by default.

- `src/lib/destructive-actions.ts` — replace `isReadOnlyHttpMethod` with `isDestructiveHttpMethod` (true only for `DELETE`)
- `src/commands/api.ts` — gate only `DELETE`
- `src/mcp/tools/core.ts` — same policy for the `ghost_api_request` MCP tool, for CLI parity

## Tests

- Updated smoke/contract tests so POST/PUT/PATCH succeed without the flag
- Added contract tests asserting POST/PUT/PATCH are allowed and DELETE still requires the flag
- Repointed the CLI + MCP destructive-guard assertions to `DELETE`

## Docs

- `README.md` and `AGENTS.md` updated to describe the method-based policy

## Validation

`pnpm lint`, `pnpm typecheck`, `pnpm test` (257 passed), `pnpm build` all clean.