### PR TITLE
fix: resolve positional slug in `post get` (#179)

### DIFF
--- a/src/commands/post.ts
+++ b/src/commands/post.ts
@@ -14,6 +14,7 @@ import {
   deletePost,
   getPost,
   listPosts,
+  looksLikeGhostId,
   publishPost,
   schedulePost,
   unschedulePost,
@@ -199,8 +200,12 @@ export function registerPostCommands(program: Command): void {
         });
       }
 
+      // An explicit --slug is always a slug; a positional value is resolved as a
+      // slug unless it looks like a Ghost ObjectId, so `get <slug>` works too.
+      const bySlug = parsed.data.slug ? true : !looksLikeGhostId(lookup);
+
       const payload = await getPost(global, lookup, {
-        bySlug: Boolean(parsed.data.slug),
+        bySlug,
         params: {
           include: parsed.data.include,
           fields: parsed.data.fields,

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -56,6 +56,17 @@ export async function listPosts(
   return collectAllPages('posts', (page) => client.posts.browse({ ...params, page, limit }));
 }
 
+const GHOST_OBJECT_ID = /^[0-9a-f]{24}$/;
+
+/**
+ * Ghost resource ids are 24-character lowercase hex ObjectIds. A positional
+ * lookup value that doesn't match is treated as a slug so `get <slug>` works
+ * as the "by id or slug" help text promises.
+ */
+export function looksLikeGhostId(value: string): boolean {
+  return GHOST_OBJECT_ID.test(value);
+}
+
 export async function getPost(
   global: GlobalOptions,
   idOrSlug: string,

--- a/tests/commands-and-run.test.ts
+++ b/tests/commands-and-run.test.ts
@@ -920,6 +920,15 @@ describe('run + commands', () => {
       fixturePrimaryPostTitle,
     );
 
+    // A positional slug (not a Ghost ObjectId) resolves via the slug endpoint,
+    // matching the "by id or slug" help text (issue #179).
+    await expect(run(['node', 'ghst', 'post', 'get', fixtureIds.postSlug, '--json'])).resolves.toBe(
+      ExitCode.SUCCESS,
+    );
+    expect(lastLogJson<{ posts: Array<{ title: string }> }>().posts[0]?.title).toBe(
+      fixturePrimaryPostTitle,
+    );
+
     await expect(
       run([
         'node',


### PR DESCRIPTION
Fixes #179.

## Problem

`ghst post get --help` describes the command as **"Get a post by id or slug"** with a positional `[id]` argument, but the positional value was routed unconditionally to Ghost's API `id` matcher. Passing a slug positionally (`ghst post get changelog-2026-07-01`) failed with an opaque 422, and the slug was only accepted via `--slug`.

## Fix

A positional lookup value that isn't a 24-character Ghost ObjectId is now treated as a slug, so `post get <slug>` resolves via the slug endpoint — matching the help text. An explicit `--slug` still always forces slug lookup.

## Test plan

- Added a smoke assertion that a positional slug resolves via the slug endpoint.
- `pnpm lint && pnpm typecheck && pnpm test && pnpm build` all pass.