### PR TITLE
fix: back `--jq` with a real jq engine (#176)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,7 @@ pnpm build
 - MCP includes `ghost_site_list` for safe configured-alias discovery without exposing stored credentials.
 - `api [endpointPath]` only accepts resource-relative paths or canonical Ghost API paths within the selected API root.
 - `api [endpointPath]` allows ordinary `POST`/`PUT`/`PATCH` writes by default; `DELETE` requests and overwrite/import routes (e.g. `POST /db/`) require `--enable-destructive-actions`.
+- `--jq <filter>` is a full jq interpreter (`@jq-tools/jq`) applied to the JSON response envelope (like `gh --jq`); use `.posts[]` to reach records, and invalid filters exit with `USAGE_ERROR`.
 - `mcp http` requires `--unsafe-public-bind` for non-loopback hosts and `--cors-origin` accepts one exact origin only.
 - MCP includes dedicated tools such as `ghost_post_schedule`, `ghost_image_upload`, `ghost_member_import`, `ghost_newsletter_list`, `ghost_tier_list`, `ghost_offer_list`, `ghost_site_list`, `ghost_theme_upload`, and `ghost_webhook_create`.
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ ghst post list --json --jq '.posts[0] | {title, slug}'
 ghst post list --json --jq '.posts[] | select(.status == "published") | .slug'
 ```
 
-Each result is printed on its own line as compact JSON, so the output stays pipe-friendly.
+Each result is printed on its own line as compact JSON, so the output stays pipe-friendly. An invalid `--jq` filter exits with code `2` (`USAGE_ERROR`) rather than leaking interpreter errors.
 
 Raw `ghst api` requests allow ordinary `POST`/`PUT`/`PATCH` writes by default; `DELETE` requests and overwrite/import routes (e.g. `POST /db/`) require `--enable-destructive-actions`.
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Interactive destructive confirmations also emit `GHST_AGENT_NOTICE:` lines on st
 | --- | --- |
 | `-v`, `--version` | Print the installed `ghst` version |
 | `--json` | Emit JSON output for automation |
-| `--jq <filter>` | Apply jq-style extraction to JSON output |
+| `--jq <filter>` | Apply a jq filter to JSON output (full jq syntax; runs against the response envelope) |
 | `--site <alias>` | Use configured site alias |
 | `--url <url>` + `--staff-token <token>` | Use direct credentials for this invocation |
 | `--enable-destructive-actions` | Allow destructive operations such as deletes |
@@ -306,12 +306,18 @@ Environment variables:
 
 ## Output, Automation, and Exit Codes
 
-JSON + jq-style extraction:
+JSON + jq filtering:
+
+`--jq` accepts full jq syntax (pipes, indexing, object construction, and built-ins) and runs against the full JSON response, so reach into the collection with `.posts[]` rather than `.[]`:
 
 ```bash
 ghst post list --json
 ghst post list --json --jq '.posts[].title'
+ghst post list --json --jq '.posts[0] | {title, slug}'
+ghst post list --json --jq '.posts[] | select(.status == "published") | .slug'
 ```
+
+Each result is printed on its own line as compact JSON, so the output stays pipe-friendly.
 
 Raw `ghst api` requests allow ordinary `POST`/`PUT`/`PATCH` writes by default; `DELETE` requests and overwrite/import routes (e.g. `POST /db/`) require `--enable-destructive-actions`.
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "prepack": "pnpm build"
   },
   "dependencies": {
+    "@jq-tools/jq": "0.0.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@tryghost/mg-json": "0.22.0",
     "@tryghost/mg-medium-export": "0.27.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@jq-tools/jq':
+        specifier: 0.0.11
+        version: 0.0.11(tslib@2.8.1)
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -846,6 +849,12 @@ packages:
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
+
+  '@jq-tools/jq@0.0.11':
+    resolution: {integrity: sha512-wTTHKZ/sBq1ECm9DGwYMesRfylbE4LIzXxsfThjv/MPTOsLEeXewKjG0nd3B7G0nG+d8SPKZq1Do677QxAso7w==}
+    hasBin: true
+    peerDependencies:
+      tslib: ^2.3.0
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -5172,6 +5181,10 @@ snapshots:
     optional: true
 
   '@isaacs/cliui@9.0.0': {}
+
+  '@jq-tools/jq@0.0.11(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,10 @@ export function buildProgram(): Command {
     .showHelpAfterError()
     .showSuggestionAfterError(true)
     .option('--json', 'Output JSON')
-    .option('--jq <filter>', 'Apply jq-style field extraction to JSON output')
+    .option(
+      '--jq <filter>',
+      'Apply a jq filter to JSON output (runs against the full response, e.g. .posts[].slug)',
+    )
     .option('--site <site>', 'Configured site alias')
     .option('--url <url>', 'Ghost site URL override')
     .option('--staff-token <token>', 'Ghost staff access token override')

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,6 +1,8 @@
 import process from 'node:process';
+import { evaluate, parse } from '@jq-tools/jq';
 import chalk from 'chalk';
 import Table from 'cli-table3';
+import { ExitCode, GhstError } from './errors.js';
 import type {
   SocialWebAccount,
   SocialWebNotification,
@@ -27,52 +29,35 @@ import type {
 import { isStdoutTty } from './tty.js';
 import type { GlobalOptions } from './types.js';
 
-function applyJqSubset(data: unknown, jq?: string): unknown {
-  if (!jq) {
-    return data;
+function describeJqError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+// Runs a jq program against the full response envelope (matching `gh --jq` and
+// standard jq), returning the stream of results. Parse/evaluation failures are
+// surfaced as usage errors instead of raw interpreter stack traces.
+function runJqFilter(data: unknown, filter: string): unknown[] {
+  try {
+    return Array.from(evaluate(parse(filter), [data]));
+  } catch (error) {
+    throw new GhstError(`Invalid --jq filter: ${describeJqError(error)}`, {
+      code: 'E_JQ_FILTER',
+      exitCode: ExitCode.USAGE_ERROR,
+    });
   }
-
-  const rootArrayPattern = /^\.\[\]\.([a-zA-Z0-9_]+)$/;
-  const nestedArrayPattern = /^\.([a-zA-Z0-9_]+)\[\]\.([a-zA-Z0-9_]+)$/;
-  const singleFieldPattern = /^\.([a-zA-Z0-9_]+)$/;
-
-  const rootMatch = jq.match(rootArrayPattern);
-  if (rootMatch) {
-    const [, field = ''] = rootMatch;
-    return Array.isArray(data)
-      ? data.map((entry) => (entry as Record<string, unknown>)[field])
-      : [];
-  }
-
-  const nestedMatch = jq.match(nestedArrayPattern);
-  if (nestedMatch) {
-    const [, collection = '', field = ''] = nestedMatch;
-    const collectionValue = (data as Record<string, unknown>)[collection];
-    return Array.isArray(collectionValue)
-      ? collectionValue.map((entry) => (entry as Record<string, unknown>)[field])
-      : [];
-  }
-
-  const singleMatch = jq.match(singleFieldPattern);
-  if (singleMatch) {
-    const [, field = ''] = singleMatch;
-    return (data as Record<string, unknown>)[field];
-  }
-
-  throw new Error(`Unsupported --jq filter: ${jq}`);
 }
 
 export function printJson(data: unknown, jq?: string): void {
-  const filtered = applyJqSubset(data, jq);
-
-  if (Array.isArray(filtered) && jq) {
-    for (const entry of filtered) {
-      console.log(JSON.stringify(entry));
-    }
+  if (!jq) {
+    console.log(JSON.stringify(data, null, 2));
     return;
   }
 
-  console.log(JSON.stringify(filtered, null, 2));
+  // jq is a stream language: print each result on its own line (compact JSONL)
+  // so the output stays pipe-friendly for scripting.
+  for (const result of runJqFilter(data, jq)) {
+    console.log(JSON.stringify(result));
+  }
 }
 
 function formatStatus(status: string, useColor: boolean): string {

--- a/tests/commands-and-run.test.ts
+++ b/tests/commands-and-run.test.ts
@@ -918,6 +918,15 @@ describe('run + commands', () => {
     await expect(
       run(['node', 'ghst', 'post', 'list', '--json', '--jq', '.posts[].title']),
     ).resolves.toBe(ExitCode.SUCCESS);
+    // Full jq syntax works end-to-end: pipes, indexing, and object construction
+    // (issue #176).
+    await expect(
+      run(['node', 'ghst', 'post', 'list', '--json', '--jq', '.posts[0] | {title, slug}']),
+    ).resolves.toBe(ExitCode.SUCCESS);
+    // A malformed filter is a usage error, not an interpreter crash.
+    await expect(
+      run(['node', 'ghst', 'post', 'list', '--json', '--jq', 'not valid jq $$']),
+    ).resolves.toBe(ExitCode.USAGE_ERROR);
     await expect(
       run(['node', 'ghst', 'post', 'get', '--slug', fixtureIds.postSlug, '--json']),
     ).resolves.toBe(ExitCode.SUCCESS);

--- a/tests/lib-output-context-errors.test.ts
+++ b/tests/lib-output-context-errors.test.ts
@@ -136,36 +136,38 @@ describe('output helpers', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const lines = () => logSpy.mock.calls.map((call) => call[0]);
 
-    // Field extraction over a nested collection (the documented idiom).
-    printJson({ posts: [{ title: 'a' }, { title: 'b' }] }, '.posts[].title');
-    expect(lines()).toEqual(['"a"', '"b"']);
+    try {
+      // Field extraction over a nested collection (the documented idiom).
+      printJson({ posts: [{ title: 'a' }, { title: 'b' }] }, '.posts[].title');
+      expect(lines()).toEqual(['"a"', '"b"']);
 
-    // Pipes.
-    logSpy.mockClear();
-    printJson({ posts: [{ slug: 'a' }, { slug: 'b' }] }, '.posts[] | .slug');
-    expect(lines()).toEqual(['"a"', '"b"']);
+      // Pipes.
+      logSpy.mockClear();
+      printJson({ posts: [{ slug: 'a' }, { slug: 'b' }] }, '.posts[] | .slug');
+      expect(lines()).toEqual(['"a"', '"b"']);
 
-    // Array indexing.
-    logSpy.mockClear();
-    printJson({ posts: [{ slug: 'a' }, { slug: 'b' }] }, '.posts[0].slug');
-    expect(lines()).toEqual(['"a"']);
+      // Array indexing.
+      logSpy.mockClear();
+      printJson({ posts: [{ slug: 'a' }, { slug: 'b' }] }, '.posts[0].slug');
+      expect(lines()).toEqual(['"a"']);
 
-    // Object construction.
-    logSpy.mockClear();
-    printJson({ posts: [{ slug: 'a', status: 'published' }] }, '.posts[] | {slug, status}');
-    expect(lines()).toEqual([JSON.stringify({ slug: 'a', status: 'published' })]);
+      // Object construction.
+      logSpy.mockClear();
+      printJson({ posts: [{ slug: 'a', status: 'published' }] }, '.posts[] | {slug, status}');
+      expect(lines()).toEqual([JSON.stringify({ slug: 'a', status: 'published' })]);
 
-    // Top-level array input still iterates its records.
-    logSpy.mockClear();
-    printJson([{ title: 'a' }, { title: 'b' }], '.[].title');
-    expect(lines()).toEqual(['"a"', '"b"']);
+      // Top-level array input still iterates its records.
+      logSpy.mockClear();
+      printJson([{ title: 'a' }, { title: 'b' }], '.[].title');
+      expect(lines()).toEqual(['"a"', '"b"']);
 
-    // Whole-document output when no filter is supplied.
-    logSpy.mockClear();
-    printJson({ ok: true });
-    expect(lines()).toEqual([JSON.stringify({ ok: true }, null, 2)]);
-
-    logSpy.mockRestore();
+      // Whole-document output when no filter is supplied.
+      logSpy.mockClear();
+      printJson({ ok: true });
+      expect(lines()).toEqual([JSON.stringify({ ok: true }, null, 2)]);
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 
   test('raises a usage error on an invalid jq filter', () => {

--- a/tests/lib-output-context-errors.test.ts
+++ b/tests/lib-output-context-errors.test.ts
@@ -132,19 +132,52 @@ describe('error helpers', () => {
 });
 
 describe('output helpers', () => {
-  test('prints json and jq-filtered json', () => {
+  test('applies real jq filters against the response envelope', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const lines = () => logSpy.mock.calls.map((call) => call[0]);
 
+    // Field extraction over a nested collection (the documented idiom).
     printJson({ posts: [{ title: 'a' }, { title: 'b' }] }, '.posts[].title');
-    printJson([{ title: 'a' }, { title: 'b' }], '.[].title');
-    printJson({ ok: true }, '.ok');
+    expect(lines()).toEqual(['"a"', '"b"']);
 
-    expect(logSpy).toHaveBeenCalled();
+    // Pipes.
+    logSpy.mockClear();
+    printJson({ posts: [{ slug: 'a' }, { slug: 'b' }] }, '.posts[] | .slug');
+    expect(lines()).toEqual(['"a"', '"b"']);
+
+    // Array indexing.
+    logSpy.mockClear();
+    printJson({ posts: [{ slug: 'a' }, { slug: 'b' }] }, '.posts[0].slug');
+    expect(lines()).toEqual(['"a"']);
+
+    // Object construction.
+    logSpy.mockClear();
+    printJson({ posts: [{ slug: 'a', status: 'published' }] }, '.posts[] | {slug, status}');
+    expect(lines()).toEqual([JSON.stringify({ slug: 'a', status: 'published' })]);
+
+    // Top-level array input still iterates its records.
+    logSpy.mockClear();
+    printJson([{ title: 'a' }, { title: 'b' }], '.[].title');
+    expect(lines()).toEqual(['"a"', '"b"']);
+
+    // Whole-document output when no filter is supplied.
+    logSpy.mockClear();
+    printJson({ ok: true });
+    expect(lines()).toEqual([JSON.stringify({ ok: true }, null, 2)]);
+
     logSpy.mockRestore();
   });
 
-  test('throws on unsupported jq syntax', () => {
-    expect(() => printJson({ posts: [] }, 'bad-filter')).toThrowError('Unsupported --jq filter');
+  test('raises a usage error on an invalid jq filter', () => {
+    let thrown: unknown;
+    try {
+      printJson({ posts: [] }, 'this is not valid jq $$');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(GhstError);
+    expect((thrown as GhstError).exitCode).toBe(ExitCode.USAGE_ERROR);
   });
 
   test('prints human list/details for resources', () => {


### PR DESCRIPTION
Closes #176.

## Problem

The global `--jq` option was advertised as "jq-style field extraction" but only recognized three hand-rolled regex patterns (`.field`, `.collection[].field`, `.[].field`). Core jq syntax failed:

| filter | before |
| --- | --- |
| `.posts[].slug` | ✅ works |
| `.[].slug` | ⚠️ silently returns nothing |
| `.posts[0].slug` (indexing) | ❌ `Unsupported --jq filter` |
| `.posts[] \| .slug` (pipe) | ❌ `Unsupported --jq filter` |
| `{slug, status}` (object construction) | ❌ `Unsupported --jq filter` |

Two papercuts: it oversold "jq-style", and `.[]` against the `{"posts":[…]}` envelope silently produced empty output.

## Change

Replace the regex matcher in `src/lib/output.ts` with the [`@jq-tools/jq`](https://www.npmjs.com/package/@jq-tools/jq) interpreter (the package @acburdine suggested — zero deps, bundles into the ESM output). Filters run against the **full response envelope**, matching `gh --jq` and standard jq, so reach into records with `.posts[]` rather than `.[]`.

- Full jq syntax now works: indexing, pipes, object construction, `select`, and the implemented built-ins.
- Parse/eval failures map to a clean `GhstError` (`USAGE_ERROR`) instead of an interpreter stack trace.
- `.[].slug` against the envelope now **errors loudly** (standard jq: `.[]` iterates object values, then `.slug` on an array is invalid) rather than silently returning nothing — resolving the silent-empty papercut.
- Output stays compact JSONL (one result per line) for pipe-friendliness.
- Honest `--help` text; README + AGENTS.md document the `.posts[]` idiom.

## Notes

- **Behavior change worth flagging:** `.[]`-on-the-envelope now errors instead of returning empty. This is consistent with `gh --jq`/real jq. Kept envelope semantics (no auto-unwrapping) so existing `.posts[]` filters are unaffected.
- `@jq-tools/jq` doesn't implement *every* built-in (no modules, limited `@formats`), but covers all core syntax plus `select/map/keys/sort_by/group_by/…`. Unimplemented built-ins produce a clean usage error, not a crash.

## Tests

TDD (red → green). Rewrote the `output.ts` unit tests to assert real jq behavior + the usage-error path, and added end-to-end pipe/object-construction/malformed-filter cases to the command smoke path.

`pnpm lint && pnpm typecheck && pnpm test && pnpm build` all pass (258 tests). No fixture changes.