### PR TITLE
fix: fall back to insecure storage when Linux Secret Service is not activatable

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -357,8 +357,17 @@ async function persistSiteCredential(
 
   if (available) {
     const credentialRef = credentialRefForAlias(alias);
-    await store.set(credentialRef, staffTokenInput);
-    return { credentialRef };
+    try {
+      await store.set(credentialRef, staffTokenInput);
+      return { credentialRef };
+    } catch (err) {
+      if (!allowInsecureStorage) {
+        throw err;
+      }
+      // store.set() failed even though isAvailable() returned true (e.g. D-Bus
+      // service became unavailable between probe and write). Fall through to
+      // plaintext storage since --insecure-storage was explicitly requested.
+    }
   }
 
   if (!allowInsecureStorage) {

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -176,7 +176,11 @@ function createLinuxAdapter(): CredentialStoreAdapter {
           LINUX_ATTR_REF,
           '__probe__',
         ]);
-        return probe.code === 0 || probe.code === 1;
+        // code 1 = credential not found (service healthy); code 0 = found.
+        // When the Secret Service is not activatable, secret-tool exits with a
+        // non-zero code AND writes a D-Bus error to stderr. A healthy "not found"
+        // response produces no stderr output, so any stderr indicates unavailability.
+        return (probe.code === 0 || probe.code === 1) && probe.stderr.trim() === '';
       } catch {
         return false;
       }

--- a/tests/credentials-and-security.test.ts
+++ b/tests/credentials-and-security.test.ts
@@ -7,6 +7,7 @@ import { readUserConfig } from '../src/lib/config.js';
 import { setCredentialStoreForTests } from '../src/lib/credentials.js';
 import { ExitCode } from '../src/lib/errors.js';
 import {
+  createBrokenCredentialStore,
   createMemoryCredentialStore,
   createUnavailableCredentialStore,
 } from './helpers/mock-credentials.js';
@@ -134,6 +135,53 @@ describe('credential storage and security defaults', () => {
     };
     expect(raw.sites?.myblog?.staffAccessToken).toBe(KEY);
     expect(raw.sites?.myblog?.credentialRef).toBeUndefined();
+  });
+
+  test('falls back to plaintext when store reports available but set throws and --insecure-storage is passed', async () => {
+    setCredentialStoreForTests(createBrokenCredentialStore());
+
+    await expect(
+      run([
+        'node',
+        'ghst',
+        'auth',
+        'login',
+        '--non-interactive',
+        '--url',
+        'https://myblog.ghost.io',
+        '--staff-token',
+        KEY,
+        '--site',
+        'myblog',
+        '--insecure-storage',
+      ]),
+    ).resolves.toBe(ExitCode.SUCCESS);
+
+    const raw = JSON.parse(await fs.readFile(path.join(configDir, 'config.json'), 'utf8')) as {
+      sites?: Record<string, { staffAccessToken?: string; credentialRef?: string }>;
+    };
+    expect(raw.sites?.myblog?.staffAccessToken).toBe(KEY);
+    expect(raw.sites?.myblog?.credentialRef).toBeUndefined();
+  });
+
+  test('re-throws store set error without --insecure-storage when store reports available but set throws', async () => {
+    setCredentialStoreForTests(createBrokenCredentialStore());
+
+    await expect(
+      run([
+        'node',
+        'ghst',
+        'auth',
+        'login',
+        '--non-interactive',
+        '--url',
+        'https://myblog.ghost.io',
+        '--staff-token',
+        KEY,
+        '--site',
+        'myblog',
+      ]),
+    ).resolves.toBe(ExitCode.GENERAL_ERROR);
   });
 
   test('migrates plaintext staff tokens into secure store on read', async () => {

--- a/tests/helpers/mock-credentials.ts
+++ b/tests/helpers/mock-credentials.ts
@@ -27,3 +27,14 @@ export function createUnavailableCredentialStore(): CredentialStore {
     delete: async () => undefined,
   };
 }
+
+export function createBrokenCredentialStore(): CredentialStore {
+  return {
+    isAvailable: async () => true,
+    set: async () => {
+      throw new Error('Failed to store credential in Secret Service: secret-tool: The name is not activatable');
+    },
+    get: async () => null,
+    delete: async () => undefined,
+  };
+}

--- a/tests/helpers/mock-credentials.ts
+++ b/tests/helpers/mock-credentials.ts
@@ -32,7 +32,9 @@ export function createBrokenCredentialStore(): CredentialStore {
   return {
     isAvailable: async () => true,
     set: async () => {
-      throw new Error('Failed to store credential in Secret Service: secret-tool: The name is not activatable');
+      throw new Error(
+        'Failed to store credential in Secret Service: secret-tool: The name is not activatable',
+      );
     },
     get: async () => null,
     delete: async () => undefined,

--- a/tests/lib-credentials.test.ts
+++ b/tests/lib-credentials.test.ts
@@ -179,6 +179,31 @@ describe.sequential('credential store adapters', () => {
     await expect(store.isAvailable()).resolves.toBe(false);
   });
 
+  test('linux adapter returns unavailable when probe exits code 1 with D-Bus stderr', async () => {
+    delete process.env.VITEST;
+    setPlatform('linux');
+    resetCredentialStoreCacheForTests();
+
+    queueSpawnOutcomes([
+      { code: 1, stderr: 'secret-tool: The name is not activatable\n' },
+    ]);
+
+    const store = getCredentialStore();
+    await expect(store.isAvailable()).resolves.toBe(false);
+  });
+
+  test('linux adapter considers service available only when probe exits cleanly with no stderr', async () => {
+    delete process.env.VITEST;
+    setPlatform('linux');
+    resetCredentialStoreCacheForTests();
+
+    // code 1 with no stderr = "not found" (service healthy)
+    queueSpawnOutcomes([{ code: 1, stderr: '' }]);
+
+    const store = getCredentialStore();
+    await expect(store.isAvailable()).resolves.toBe(true);
+  });
+
   test('linux adapter handles input piping and error branches', async () => {
     delete process.env.VITEST;
     setPlatform('linux');

--- a/tests/lib-credentials.test.ts
+++ b/tests/lib-credentials.test.ts
@@ -184,9 +184,7 @@ describe.sequential('credential store adapters', () => {
     setPlatform('linux');
     resetCredentialStoreCacheForTests();
 
-    queueSpawnOutcomes([
-      { code: 1, stderr: 'secret-tool: The name is not activatable\n' },
-    ]);
+    queueSpawnOutcomes([{ code: 1, stderr: 'secret-tool: The name is not activatable\n' }]);
 
     const store = getCredentialStore();
     await expect(store.isAvailable()).resolves.toBe(false);


### PR DESCRIPTION
## Summary

- `isAvailable()` in the Linux credential adapter returned `true` when `secret-tool lookup` exited with code 1 **and** a D-Bus error in stderr (e.g. `The name is not activatable`), because the probe only checked exit code. A healthy "not found" response also exits 1 but produces no stderr, so the fix checks that stderr is empty before reporting available.
- Added a `try/catch` around `store.set()` in `persistSiteCredential` so that if `set()` throws despite `isAvailable()` returning `true` (race or stale probe), the error still falls through to plaintext storage when `--insecure-storage` was passed, rather than surfacing an unhandled store error.

## Test plan

- [ ] `linux adapter returns unavailable when probe exits code 1 with D-Bus stderr` — unit test in `lib-credentials.test.ts`
- [ ] `linux adapter considers service available only when probe exits cleanly with no stderr` — confirms the healthy "not found" path still works
- [ ] `falls back to plaintext when store reports available but set throws and --insecure-storage is passed` — integration test in `credentials-and-security.test.ts`
- [ ] `re-throws store set error without --insecure-storage when store reports available but set throws` — integration test confirming error surfaces correctly without the flag
- [ ] All four new tests pass; pre-existing test suite unaffected by these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)