### PR TITLE
fix(mcp): advertise per-call site arg on no-argument MCP tools

### DIFF
--- a/src/mcp/tools/core.ts
+++ b/src/mcp/tools/core.ts
@@ -178,9 +178,6 @@ const mcpSiteArgSchema = SiteAliasSchema.optional();
 const mcpSiteSchema = z.object({
   site: mcpSiteArgSchema,
 });
-const mcpOptionalSiteOnlySchema = z
-  .union([mcpSiteSchema, z.undefined()])
-  .transform((value) => value ?? {});
 
 type ExtendableZodObject = AnySchema & {
   safeExtend?: (shape: { site: typeof mcpSiteArgSchema }) => AnySchema;
@@ -191,7 +188,11 @@ function withMcpSiteSchema<InputSchema extends AnySchema | undefined>(
   inputSchema?: InputSchema,
 ): AnySchema {
   if (!inputSchema) {
-    return mcpOptionalSiteOnlySchema;
+    // No-argument tools still accept the optional per-call `site`. This must be a
+    // plain object schema: the MCP SDK derives a tool's advertised JSON Schema from
+    // `normalizeObjectSchema`, which only surfaces `properties` for object schemas.
+    // Wrapping in a union/transform/default hides `site` from `tools/list`.
+    return z.object({ site: mcpSiteArgSchema });
   }
 
   const objectSchema = inputSchema as ExtendableZodObject;

--- a/src/mcp/tools/core.ts
+++ b/src/mcp/tools/core.ts
@@ -188,11 +188,11 @@ function withMcpSiteSchema<InputSchema extends AnySchema | undefined>(
   inputSchema?: InputSchema,
 ): AnySchema {
   if (!inputSchema) {
-    // No-argument tools still accept the optional per-call `site`. This must be a
-    // plain object schema: the MCP SDK derives a tool's advertised JSON Schema from
-    // `normalizeObjectSchema`, which only surfaces `properties` for object schemas.
-    // Wrapping in a union/transform/default hides `site` from `tools/list`.
-    return z.object({ site: mcpSiteArgSchema });
+    // No-argument tools still accept the optional per-call `site`. Reuse the shared
+    // object schema: the MCP SDK derives a tool's advertised JSON Schema from
+    // `normalizeObjectSchema`, which only surfaces `properties` for object schemas,
+    // so wrapping in a union/transform/default would hide `site` from `tools/list`.
+    return mcpSiteSchema;
   }
 
   const objectSchema = inputSchema as ExtendableZodObject;

--- a/tests/mcp-core-tools.test.ts
+++ b/tests/mcp-core-tools.test.ts
@@ -681,7 +681,7 @@ describe('mcp core tool registration', () => {
     const siteListSchema = tools.get('ghost_site_list')?.meta.inputSchema as {
       safeParse: (value: unknown) => { success: boolean; data?: unknown; error?: Error };
     };
-    expect(siteListSchema.safeParse(undefined)).toMatchObject({
+    expect(siteListSchema.safeParse({})).toMatchObject({
       success: true,
       data: {},
     });

--- a/tests/mcp-http-integration.test.ts
+++ b/tests/mcp-http-integration.test.ts
@@ -49,6 +49,7 @@ function parseMcpJsonResponse(body: string): {
     tools?: Array<{
       name: string;
       _meta?: Record<string, unknown>;
+      inputSchema?: { properties?: Record<string, unknown> };
     }>;
   };
 } {
@@ -201,14 +202,13 @@ describe.sequential('mcp http integration', () => {
         'ghst/toolGroup': 'site',
         'ghst/toolGroupTitle': 'Site',
       });
-      expect(JSON.stringify(siteTool)).toContain('"site"');
+      // A no-argument tool must still advertise the optional per-call `site` in its
+      // published input schema, otherwise clients cannot discover per-call targeting.
+      // (Asserting the schema itself, not a substring match that also hits `_meta`.)
+      expect(siteTool?.inputSchema?.properties).toHaveProperty('site');
 
-      const noArgumentsCall = await mcpPost(baseUrl, 3, 'tools/call', {
-        name: 'ghost_site_list',
-      });
-      expect(noArgumentsCall.status).toBe(200);
-      expect(noArgumentsCall.body).toContain('"sites"');
-
+      // No-argument tools now expose an object input schema (so `site` is
+      // discoverable), which means an empty arguments object is accepted...
       const emptyArgumentsCall = await mcpPost(baseUrl, 4, 'tools/call', {
         name: 'ghost_site_list',
         arguments: {},

--- a/tests/mcp-http-integration.test.ts
+++ b/tests/mcp-http-integration.test.ts
@@ -227,4 +227,88 @@ describe.sequential('mcp http integration', () => {
       await runPromise;
     }
   });
+
+  test('every published tool advertises the optional per-call site argument', async () => {
+    const port = await getFreePort();
+    const runPromise = runMcpHttp(
+      () => createGhostMcpServer({}, { enabledGroups: parseToolGroups('all') }),
+      { host: '127.0.0.1', port, authToken: 'test-token' },
+    );
+
+    const baseUrl = `http://127.0.0.1:${port}/mcp`;
+
+    try {
+      await waitForServer(baseUrl);
+
+      await fetch(baseUrl, {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer test-token',
+          accept: 'application/json, text/event-stream',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-11-25',
+            capabilities: {},
+            clientInfo: { name: 'test', version: '0.1' },
+          },
+        }),
+      });
+
+      await fetch(baseUrl, {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer test-token',
+          accept: 'application/json, text/event-stream',
+          'content-type': 'application/json',
+          'mcp-protocol-version': '2025-11-25',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} }),
+      });
+
+      const toolsListResponse = await fetch(baseUrl, {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer test-token',
+          accept: 'application/json, text/event-stream',
+          'content-type': 'application/json',
+          'mcp-protocol-version': '2025-11-25',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }),
+      });
+
+      const tools = parseMcpJsonResponse(await toolsListResponse.text()).result?.tools ?? [];
+      expect(tools.length).toBeGreaterThan(0);
+
+      // withMcpSiteSchema injects `site` into every tool. Assert the invariant across
+      // the whole surface so a tool registered with a schema shape that drops `site`
+      // from the published `tools/list` projection (as the old no-argument fallback
+      // did) fails here instead of silently shipping.
+      const missingSite = tools
+        .filter((tool) => tool.inputSchema?.properties?.site === undefined)
+        .map((tool) => tool.name);
+      expect(missingSite).toEqual([]);
+
+      // Explicitly cover the no-argument tools, the ones the fallback affected.
+      const names = new Set(tools.map((tool) => tool.name));
+      for (const name of [
+        'ghost_site_info',
+        'ghost_site_list',
+        'ghost_setting_list',
+        'ghost_socialweb_status',
+        'ghost_socialweb_enable',
+        'ghost_socialweb_disable',
+        'ghost_socialweb_notifications_count',
+      ]) {
+        expect(names.has(name)).toBe(true);
+      }
+    } finally {
+      process.emit('SIGINT');
+      await runPromise;
+    }
+  });
 });


### PR DESCRIPTION
## Problem

Six no-argument MCP tools published an **empty input schema** in `tools/list`, so the documented optional per-call `site` argument was invisible to clients — they could not target a configured site alias per call for these tools:

- `ghost_site_info`
- `ghost_setting_list`
- `ghost_socialweb_status`
- `ghost_socialweb_enable`
- `ghost_socialweb_disable`
- `ghost_socialweb_notifications_count`

(`ghost_site_list` was equally affected; it is inherently global but was in the same code path.)

Observed via a real `tools/list` roundtrip:

```jsonc
// before
"ghost_site_info": { "inputSchema": { "type": "object", "properties": {} } }
// after
"ghost_site_info": { "inputSchema": { "type": "object",
  "properties": { "site": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" } } } }
```

## Cause

For tools without their own input schema, `withMcpSiteSchema` returned a `z.union([{ site? }, undefined]).transform(...)`. The MCP SDK derives a tool's advertised JSON Schema via `normalizeObjectSchema`, which only surfaces `properties` for **object** schemas — a union/transform normalizes to nothing, so the SDK emitted `{"type":"object","properties":{}}`. The union existed only to tolerate an omitted `arguments` field, but that same non-object shape is what erased `site` from discovery.

## Fix

Return a plain `z.object({ site })` for no-argument tools — the exact shape every other tool already uses — and drop the now-dead union schema. All 91 tools now advertise `site`.

## Tests

- Strengthened the `mcp http` `tools/list` assertion. The previous check, `expect(JSON.stringify(siteTool)).toContain('"site"')`, passed for the wrong reason (it matched `_meta['ghst/toolGroup']: 'site'`) and masked this gap. It now asserts `inputSchema.properties` contains `site`. **Verified failing on `main`, passing with this change.**
- `pnpm lint`, `format:check`, `typecheck`, `test` (full suite), and `build` all pass.

## Behaviour note

These six tools now require an `arguments` object (even `{}`), consistent with the other 85 tools, which already do. A call that omits `arguments` **entirely** on these specific tools is now rejected; the common `arguments: {}` / `{ site }` paths are unaffected. The SDK couples the JSON-schema projection and argument validation through the same `normalizeObjectSchema` result, so a single schema cannot both advertise `site` and accept a fully-omitted `arguments` field — happy to adjust the approach if maintainers prefer to preserve the latter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)