### PR TITLE
fix(member): AND --status against the whole --filter

### DIFF
--- a/src/commands/member.ts
+++ b/src/commands/member.ts
@@ -93,15 +93,22 @@ export function registerMemberCommands(program: Command): void {
       }
 
       const allPages = parsed.data.limit === 'all';
+      // Parenthesize the user filter so `--status` ANDs against the whole filter.
+      // NQL binds `+` (AND) tighter than `,` (OR), so an unparenthesized
+      // `<filter>+status:<status>` would attach the status to only the last OR
+      // term instead of the entire filter.
       const combinedFilter =
         parsed.data.filter && parsed.data.status
-          ? `${parsed.data.filter}+status:${parsed.data.status}`
+          ? `(${parsed.data.filter})+status:${parsed.data.status}`
           : (parsed.data.filter ??
             (parsed.data.status ? `status:${parsed.data.status}` : undefined));
+      // `status` is folded into `filter`; drop it so it is not also sent as a
+      // standalone query param.
+      const { status: _status, ...listInput } = parsed.data;
       const payload = await listMembers(
         global,
         {
-          ...parsed.data,
+          ...listInput,
           filter: combinedFilter,
           limit: parsed.data.limit === 'all' ? undefined : parsed.data.limit,
         },

--- a/tests/commands-and-run.test.ts
+++ b/tests/commands-and-run.test.ts
@@ -3293,4 +3293,45 @@ describe('run + commands', () => {
       'Warning: Social web is enabled, but the social web service is not reachable yet.',
     );
   });
+
+  test('member list ANDs --status against the whole --filter (parenthesized)', async () => {
+    const requests: Array<{ method: string; pathname: string; url: URL }> = [];
+    installGhostFixtureFetchMock({
+      onRequest: async ({ method, pathname, url }) => {
+        requests.push({ method, pathname, url: new URL(url.toString()) });
+        return undefined;
+      },
+    });
+
+    await expect(
+      run([
+        'node',
+        'ghst',
+        '--url',
+        'https://myblog.ghost.io',
+        '--staff-token',
+        KEY,
+        'member',
+        'list',
+        '--filter',
+        'label:vip,label:founders',
+        '--status',
+        'paid',
+      ]),
+    ).resolves.toBe(ExitCode.SUCCESS);
+
+    const listRequest = requests.find(
+      (request) => request.method === 'GET' && request.pathname.endsWith('/members/'),
+    );
+    // The user filter must be parenthesized so `--status` ANDs against the whole
+    // filter. NQL binds `+` (AND) tighter than `,` (OR), so an unparenthesized
+    // `label:vip,label:founders+status:paid` parses as
+    // `label:vip OR (label:founders AND status:paid)` — dropping the status
+    // constraint from the first OR branch.
+    expect(listRequest?.url.searchParams.get('filter')).toBe(
+      '(label:vip,label:founders)+status:paid',
+    );
+    // `--status` is folded into the filter; it must not also leak as its own param.
+    expect(listRequest?.url.searchParams.has('status')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Problem

`member list --filter <f> --status <s>` combines the two into a single NQL filter, but does not parenthesize the user-supplied filter:

```js
// src/commands/member.ts
`${parsed.data.filter}+status:${parsed.data.status}`
```

NQL binds `+` (AND) more tightly than `,` (OR), so any user filter containing a top-level OR is mis-grouped. For example:

```
ghst member list --filter 'label:vip,label:founders' --status paid
```

emits the filter `label:vip,label:founders+status:paid`, which NQL parses as:

```
label:vip OR (label:founders AND status:paid)
```

So the `--status paid` constraint is silently **not** applied to the `label:vip` branch — members with the wrong status are returned. `AGENTS.md` documents `--status` as composing with (AND-ing) `--filter`.

A second, minor issue: `status` also leaked through the `...parsed.data` spread as a standalone `status=` query param (harmless — Ghost ignores it — but unintended).

## Fix

Parenthesize the user filter so the status ANDs against the whole thing:

```js
`(${parsed.data.filter})+status:${parsed.data.status}`
```

This is the same defensive-parenthesization pattern already used in `src/lib/client.ts` for the comment-thread filter. Also drop `status` from the params passed to `listMembers`, since it is folded into the filter.

Single-clause filters (no top-level OR) are unaffected — `label:vip+status:paid` and `(label:vip)+status:paid` are equivalent — which is why this went unnoticed.

## Tests

Added a `member list` test that drives the CLI and asserts the outgoing `filter` query param is `(label:vip,label:founders)+status:paid` and that no standalone `status` param is sent. It fails on `main` (emits the unparenthesized form) and passes with this change. `lint` / `format:check` / `typecheck` / full `test` / `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)